### PR TITLE
Add context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "^16.0.0",
     "react-autocomplete": "^1.7.2",
     "react-contenteditable": "^2.0.5",
+    "react-cursor-position": "^2.3.0",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-document-title": "^2.0.3",

--- a/src/neo/components/ContextMenu/index.jsx
+++ b/src/neo/components/ContextMenu/index.jsx
@@ -4,6 +4,15 @@ import ContextMenuContainer from "../ContextMenuContainer";
 import "./style.css";
 
 export default class ContextMenu extends React.Component {  
+  static propTypes = {
+    width: PropTypes.number,
+    padding: PropTypes.number,
+    onContextMenu: PropTypes.func,
+    isOpen: PropTypes.bool,
+    position: PropTypes.any,
+    rect: PropTypes.any,
+    children: PropTypes.node
+  };
   render() {
     return (
       <ContextMenuContainer width={this.props.width} padding={this.props.padding} onContextMenu={this.props.onContextMenu} isOpen={this.props.isOpen} 

--- a/src/neo/components/ContextMenu/index.jsx
+++ b/src/neo/components/ContextMenu/index.jsx
@@ -4,9 +4,9 @@ import ContextMenuContainer from "../ContextMenuContainer";
 import "./style.css";
 
 export default class ContextMenu extends React.Component {  
-  render() {        
+  render() {
     return (
-      <ContextMenuContainer width={this.props.width} padding={this.props.padding} index={this.props.index} onContextMenu={this.props.onContextMenu} isOpen={this.props.isOpen} 
+      <ContextMenuContainer width={this.props.width} padding={this.props.padding} onContextMenu={this.props.onContextMenu} isOpen={this.props.isOpen} 
         position={this.props.position} rect={this.props.rect}>
         <ul className="buttons">
           {this.props.children}

--- a/src/neo/components/ContextMenu/index.jsx
+++ b/src/neo/components/ContextMenu/index.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+import ContextMenuContainer from "../ContextMenuContainer";
+import "./style.css";
+
+export default class ContextMenu extends React.Component {  
+  render() {        
+    return (
+      <ContextMenuContainer width={this.props.width} padding={this.props.padding} index={this.props.index} onContextMenu={this.props.onContextMenu} isOpen={this.props.isOpen} 
+        position={this.props.position} rect={this.props.rect}>
+        <ul className="buttons">
+          {this.props.children}
+        </ul>
+      </ContextMenuContainer>      
+    );
+  }
+}
+

--- a/src/neo/components/ContextMenu/style.css
+++ b/src/neo/components/ContextMenu/style.css
@@ -1,0 +1,18 @@
+.menu.content .buttons li a {
+  display: block;
+  cursor: pointer;
+  padding: 10px 20px;
+}
+
+.menu.content .buttons li a:hover {
+  background-color: #F3F3F3;
+}
+
+.menu.content .buttons li a .label {
+  float: right;
+  color: #929292;
+}
+
+.menu.content .buttons li hr {
+  margin-left: 20px;
+}

--- a/src/neo/components/ContextMenuContainer/index.jsx
+++ b/src/neo/components/ContextMenuContainer/index.jsx
@@ -1,0 +1,142 @@
+import React from "react";
+import PropTypes from "prop-types";
+import "./style.css";
+import { findDOMNode } from "react-dom";
+import ReactModal from "react-modal";
+import classNames from "classnames";
+import { Transition } from "react-transition-group";
+import {observer} from "mobx-react";
+
+export const MenuDirections = {
+  Left: "left",
+  Bottom: "bottom"
+};
+
+const duration = 100;
+
+const transitionStyles = {
+  entering: {
+    opacity: 0,
+    transform: "scale(0, 0)"
+  },
+  entered: {
+    opacity: 1,
+    transform: "scale(1, 1)"
+  },
+  exiting: {
+    opacity: 0,
+    transform: "scale(0, 0)"
+  },
+  exited: {
+    opacity: 0,
+    transform: "scale(0, 0)"
+  }
+};
+
+class Menu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.handleClosing = this.handleClosing.bind(this);
+  }
+  static propTypes = {
+    isOpen: PropTypes.bool,
+    children: PropTypes.node,
+    node: PropTypes.any,
+    width: PropTypes.number,
+    direction: PropTypes.string,
+    padding: PropTypes.number,
+    onClick: PropTypes.func,
+    requestClose: PropTypes.func.isRequired
+  };
+  static defaultProps = {
+    isOpen: false,
+    width: 200,
+    padding: 5,
+    direction: MenuDirections.Left
+  };
+  handleClosing(e) {
+    this.props.requestClose(e);
+  }
+  render() {    
+    let directionStyles = {};
+    if(this.props.rect){      
+      if(this.props.rect.x+this.props.rect.width < this.props.rect.x + this.props.position.x + this.props.width ){
+        directionStyles = {
+          top : this.props.rect.y + this.props.position.y + "px",
+          left : this.props.rect.x + this.props.rect.width - this.props.width + "px",
+          transformOrigin: `${this.props.width / 2}px 0px 0px`
+        };
+      }else{
+        directionStyles = {
+          top : this.props.rect.y + this.props.position.y + "px",
+          left : this.props.rect.x + this.props.position.x + "px",
+          transformOrigin: `${this.props.width / 2}px 0px 0px`
+        };
+      }
+      
+    }    
+
+    return (
+      <Transition in={this.props.isOpen} timeout={duration}>
+        {(status) => (
+          <ReactModal
+            className={classNames("menu", "content")}
+            isOpen={this.props.isOpen}
+            ariaHideApp={false}
+            shouldCloseOnOverlayClick={true}
+            closeTimeoutMS={300}
+            onRequestClose={this.handleClosing}
+            style={{
+              overlay: {
+                backgroundColor: "transparent",
+                zIndex: "1000"
+              },
+              content: Object.assign({
+                width: `${this.props.width}px`
+              }, directionStyles, transitionStyles[status])
+            }}
+          >
+            <div onClick={this.props.onClick}>
+              {this.props.children}
+            </div>
+          </ReactModal>
+        )}
+      </Transition>
+    );
+  }
+}
+
+export default class ContextMenuContainer extends React.Component {  
+  constructor(props) {
+    super(props);           
+    this.close = this.close.bind(this);    
+  }
+  
+  static defaultProps = {
+    closeOnClick: true
+  };
+  
+  close(e) {    
+    e.preventDefault();
+    e.stopPropagation();    
+    this.props.onContextMenu();
+  }
+  render() {     
+    return ([             
+        <Menu
+          key="menu"
+          isOpen={this.props.isOpen}          
+          node={this.node}
+          onClick={this.props.closeOnClick ? this.close : null}
+          requestClose={this.close}
+          width={this.props.width}
+          direction={this.props.direction}
+          padding={this.props.padding}
+          position={this.props.position}
+          rect={this.props.rect}>          
+          {this.props.children}      
+        </Menu>      
+    ]);
+  }
+}

--- a/src/neo/components/ContextMenuContainer/index.jsx
+++ b/src/neo/components/ContextMenuContainer/index.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import "./style.css";
-import { findDOMNode } from "react-dom";
 import ReactModal from "react-modal";
 import classNames from "classnames";
 import { Transition } from "react-transition-group";
+import "./style.css";
 
 const duration = 100;
 
@@ -39,7 +38,9 @@ class Menu extends React.Component {
     width: PropTypes.number,
     padding: PropTypes.number,
     onClick: PropTypes.func,
-    requestClose: PropTypes.func.isRequired
+    requestClose: PropTypes.func.isRequired,
+    position: PropTypes.any,
+    rect: PropTypes.any
   };
   static defaultProps = {
     isOpen: false,
@@ -104,7 +105,16 @@ export default class ContextMenuContainer extends React.Component {
     super(props);           
     this.close = this.close.bind(this);    
   }
-  
+  static propTypes = {
+    width: PropTypes.number,
+    padding: PropTypes.number,
+    onContextMenu: PropTypes.func,
+    isOpen: PropTypes.bool,
+    position: PropTypes.any,
+    rect: PropTypes.any,
+    children: PropTypes.node,
+    closeOnClick: PropTypes.bool    
+  };
   static defaultProps = {
     closeOnClick: true
   };
@@ -116,17 +126,17 @@ export default class ContextMenuContainer extends React.Component {
   }
   render() {     
     return ([             
-        <Menu
-          key="menu"
-          isOpen={this.props.isOpen}
-          onClick={this.props.closeOnClick ? this.close : null}
-          requestClose={this.close}
-          width={this.props.width}
-          padding={this.props.padding}
-          position={this.props.position}
-          rect={this.props.rect}>          
-          {this.props.children}      
-        </Menu>      
+      <Menu
+        key="menu"
+        isOpen={this.props.isOpen}
+        onClick={this.props.closeOnClick ? this.close : null}
+        requestClose={this.close}
+        width={this.props.width}
+        padding={this.props.padding}
+        position={this.props.position}
+        rect={this.props.rect}>          
+        {this.props.children}      
+      </Menu>      
     ]);
   }
 }

--- a/src/neo/components/ContextMenuContainer/index.jsx
+++ b/src/neo/components/ContextMenuContainer/index.jsx
@@ -5,12 +5,6 @@ import { findDOMNode } from "react-dom";
 import ReactModal from "react-modal";
 import classNames from "classnames";
 import { Transition } from "react-transition-group";
-import {observer} from "mobx-react";
-
-export const MenuDirections = {
-  Left: "left",
-  Bottom: "bottom"
-};
 
 const duration = 100;
 
@@ -42,9 +36,7 @@ class Menu extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool,
     children: PropTypes.node,
-    node: PropTypes.any,
     width: PropTypes.number,
-    direction: PropTypes.string,
     padding: PropTypes.number,
     onClick: PropTypes.func,
     requestClose: PropTypes.func.isRequired
@@ -52,8 +44,7 @@ class Menu extends React.Component {
   static defaultProps = {
     isOpen: false,
     width: 200,
-    padding: 5,
-    direction: MenuDirections.Left
+    padding: 5
   };
   handleClosing(e) {
     this.props.requestClose(e);
@@ -82,6 +73,7 @@ class Menu extends React.Component {
         {(status) => (
           <ReactModal
             className={classNames("menu", "content")}
+            key={"menuModal"}
             isOpen={this.props.isOpen}
             ariaHideApp={false}
             shouldCloseOnOverlayClick={true}
@@ -97,7 +89,7 @@ class Menu extends React.Component {
               }, directionStyles, transitionStyles[status])
             }}
           >
-            <div onClick={this.props.onClick}>
+            <div onClick={this.props.onClick} id={"menuModal"}>
               {this.props.children}
             </div>
           </ReactModal>
@@ -119,19 +111,17 @@ export default class ContextMenuContainer extends React.Component {
   
   close(e) {    
     e.preventDefault();
-    e.stopPropagation();    
+    e.stopPropagation();
     this.props.onContextMenu();
   }
   render() {     
     return ([             
         <Menu
           key="menu"
-          isOpen={this.props.isOpen}          
-          node={this.node}
+          isOpen={this.props.isOpen}
           onClick={this.props.closeOnClick ? this.close : null}
           requestClose={this.close}
           width={this.props.width}
-          direction={this.props.direction}
           padding={this.props.padding}
           position={this.props.position}
           rect={this.props.rect}>          

--- a/src/neo/components/ContextMenuContainer/style.css
+++ b/src/neo/components/ContextMenuContainer/style.css
@@ -1,0 +1,18 @@
+.menu.content .buttons li a {
+  display: block;
+  cursor: pointer;
+  padding: 10px 20px;
+}
+
+.menu.content .buttons li a:hover {
+  background-color: #F3F3F3;
+}
+
+.menu.content .buttons li a .label {
+  float: right;
+  color: #929292;
+}
+
+.menu.content .buttons li hr {
+  margin-left: 20px;
+}

--- a/src/neo/components/Test/index.jsx
+++ b/src/neo/components/Test/index.jsx
@@ -24,6 +24,10 @@ import ListMenu, { ListMenuItem } from "../ListMenu";
 import MoreButton from "../ActionButtons/More";
 import RemoveButton from "../ActionButtons/Remove";
 import "./style.css";
+import ContextMenu from "../ContextMenu";
+import ReactDOM from "react-dom";
+import UiState from "../../stores/view/UiState";
+import { observer } from "mobx-react";
 
 export const Type = "test";
 const testSource = {
@@ -44,8 +48,12 @@ function collect(connect, monitor) {
     isDragging: monitor.isDragging()
   };
 }
-
+@observer
 export default class Test extends React.Component {
+  constructor(props){
+    super(props);
+    this.state ={};
+  }
   static propTypes = {
     className: PropTypes.string,
     test: PropTypes.object.isRequired,
@@ -68,6 +76,7 @@ export default class Test extends React.Component {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
+      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentDidUpdate(prevProps) {
@@ -76,6 +85,7 @@ export default class Test extends React.Component {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
+      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentWillUnmount() {
@@ -102,6 +112,11 @@ export default class Test extends React.Component {
     }
   }
   render() {
+    const menuList = <div>
+      <ListMenuItem onClick={() => this.props.renameTest(this.props.test.name, this.props.test.setName)}>Rename</ListMenuItem>
+      <ListMenuItem onClick={this.props.removeTest}>Delete</ListMenuItem>
+    </div>
+
     const rendered = <a
       href="#"
       ref={(node) => { this.node = node; }}
@@ -110,18 +125,20 @@ export default class Test extends React.Component {
       onFocus={this.handleClick.bind(this, this.props.test, this.props.suite)}
       onKeyDown={this.handleKeyDown.bind(this)}
       tabIndex={this.props.selected ? "0" : "-1"}
+      onContextMenu={this.props.onContextMenu}
       style={{
         display: this.props.isDragging ? "none" : "flex"
       }}>
       <span>{this.props.test.name}</span>
       {this.props.renameTest ?
-        <ListMenu width={130} padding={-5} opener={
-          <MoreButton />
-        }>
-          <ListMenuItem onClick={() => this.props.renameTest(this.props.test.name, this.props.test.setName)}>Rename</ListMenuItem>
-          <ListMenuItem onClick={this.props.removeTest}>Delete</ListMenuItem>
+        <ListMenu width={130} padding={-5} opener={<MoreButton />}>
+          {menuList}
         </ListMenu> :
         <RemoveButton onClick={(e) => {e.stopPropagation(); this.props.removeTest();}} />}
+        <ContextMenu width={130} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
+            isOpen ={UiState.isContextOpenNavigation[this.props.index]} position={this.props.position}>
+              {menuList}
+        </ContextMenu>
     </a>;
     return (this.props.suite ? this.props.connectDragSource(rendered) : rendered);
   }

--- a/src/neo/components/Test/index.jsx
+++ b/src/neo/components/Test/index.jsx
@@ -25,7 +25,7 @@ import MoreButton from "../ActionButtons/More";
 import RemoveButton from "../ActionButtons/Remove";
 import "./style.css";
 import ContextMenu from "../ContextMenu";
-import ReactDOM from "react-dom";
+import { findDOMNode } from "react-dom";
 import UiState from "../../stores/view/UiState";
 import { observer } from "mobx-react";
 
@@ -69,14 +69,17 @@ export default class Test extends React.Component {
     setDrag: PropTypes.func,
     moveSelectionUp: PropTypes.func,
     moveSelectionDown: PropTypes.func,
-    setSectionFocus: PropTypes.func
+    setSectionFocus: PropTypes.func,
+    index: PropTypes.number,
+    position: PropTypes.any,
+    onContextMenu: PropTypes.func
   };
   componentDidMount() {
     if (this.props.selected) {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
-      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentDidUpdate(prevProps) {
@@ -85,7 +88,7 @@ export default class Test extends React.Component {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
-      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentWillUnmount() {
@@ -115,7 +118,7 @@ export default class Test extends React.Component {
     const menuList = <div>
       <ListMenuItem onClick={() => this.props.renameTest(this.props.test.name, this.props.test.setName)}>Rename</ListMenuItem>
       <ListMenuItem onClick={this.props.removeTest}>Delete</ListMenuItem>
-    </div>
+    </div>;
 
     const rendered = <a
       href="#"

--- a/src/neo/components/Test/index.jsx
+++ b/src/neo/components/Test/index.jsx
@@ -79,7 +79,7 @@ export default class Test extends React.Component {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
-      this.setState({rect: findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).getBoundingClientRect()}); // eslint-disable-line react/no-find-dom-node
     }
   }
   componentDidUpdate(prevProps) {
@@ -88,7 +88,7 @@ export default class Test extends React.Component {
       this.props.setSectionFocus("navigation", () => {
         this.node.focus();
       });
-      this.setState({rect: findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).getBoundingClientRect()}); // eslint-disable-line react/no-find-dom-node
     }
   }
   componentWillUnmount() {
@@ -138,10 +138,10 @@ export default class Test extends React.Component {
           {menuList}
         </ListMenu> :
         <RemoveButton onClick={(e) => {e.stopPropagation(); this.props.removeTest();}} />}
-        <ContextMenu width={130} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
-            isOpen ={UiState.isContextOpenNavigation[this.props.index]} position={this.props.position}>
-              {menuList}
-        </ContextMenu>
+      <ContextMenu width={130} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
+        isOpen ={UiState.isContextOpenNavigation[this.props.index]} position={this.props.position}>
+        {menuList}
+      </ContextMenu>
     </a>;
     return (this.props.suite ? this.props.connectDragSource(rendered) : rendered);
   }

--- a/src/neo/components/TestList/index.jsx
+++ b/src/neo/components/TestList/index.jsx
@@ -28,13 +28,13 @@ import ReactCursorPosition from "react-cursor-position";
 import "./style.css";
 
 @inject("renameTest") @observer
-export default class TestList extends Component {
+export default class TestList extends Component {  
   componentDidMount() {
-    document.addEventListener('contextmenu', this.handleContextMenu);
-  };
+    document.addEventListener("contextmenu", this.handleContextMenu);
+  }
   componentWillUnmount() {
-    document.removeEventListener('contextmenu', this.handleContextMenu);
-  };  
+    document.removeEventListener("contextmenu", this.handleContextMenu);
+  }
   handleContextMenu(e){
     e.preventDefault();
   } 
@@ -73,7 +73,7 @@ export default class TestList extends Component {
                   setSectionFocus={UiState.setSectionFocus}
                   onContextMenu={() => { this.props.onContextMenu(index); }}
                 />}
-              </ReactCursorPosition>
+            </ReactCursorPosition>
           </li>
         ))}
       </ul>
@@ -84,6 +84,7 @@ export default class TestList extends Component {
     collapsed: PropTypes.bool,
     suite: PropTypes.object,
     renameTest: PropTypes.func,
-    removeTest: PropTypes.func.isRequired
+    removeTest: PropTypes.func.isRequired,
+    onContextMenu: PropTypes.func    
   };
 }

--- a/src/neo/components/TestList/index.jsx
+++ b/src/neo/components/TestList/index.jsx
@@ -23,7 +23,7 @@ import classNames from "classnames";
 import Test, { DraggableTest } from "../Test";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
-import ReactCursorPosition from 'react-cursor-position';
+import ReactCursorPosition from "react-cursor-position";
 
 import "./style.css";
 

--- a/src/neo/components/TestList/index.jsx
+++ b/src/neo/components/TestList/index.jsx
@@ -23,42 +23,57 @@ import classNames from "classnames";
 import Test, { DraggableTest } from "../Test";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
+import ReactCursorPosition from 'react-cursor-position';
+
 import "./style.css";
 
 @inject("renameTest") @observer
 export default class TestList extends Component {
+  componentDidMount() {
+    document.addEventListener('contextmenu', this.handleContextMenu);
+  };
+  componentWillUnmount() {
+    document.removeEventListener('contextmenu', this.handleContextMenu);
+  };  
+  handleContextMenu(e){
+    e.preventDefault();
+  } 
   render() {
     return (
       <ul className={classNames("tests", {"active": !this.props.collapsed})}>
         {this.props.tests.map((test, index) => (
           <li key={test.id}>
-            {this.props.suite ?
-              <DraggableTest
-                className={PlaybackState.testState.get(test.id)}
-                test={test}
-                suite={this.props.suite}
-                selected={UiState.selectedTest.test && test.id === UiState.selectedTest.test.id && this.props.suite.id === (UiState.selectedTest.suite ? UiState.selectedTest.suite.id : undefined)}
-                changed={UiState.getTestState(test).modified}
-                selectTest={UiState.selectTest}
-                dragInProgress={UiState.dragInProgress}
-                setDrag={UiState.setDrag}
-                removeTest={() => { this.props.removeTest(test); }}
-                moveSelectionUp={() => { UiState.selectTestByIndex(index - 1, this.props.suite); }}
-                moveSelectionDown={() => { UiState.selectTestByIndex(index + 1, this.props.suite); }}
-                setSectionFocus={UiState.setSectionFocus}
-              /> :
-              <Test
-                className={PlaybackState.testState.get(test.id)}
-                test={test}
-                selected={UiState.selectedTest.test && test.id === UiState.selectedTest.test.id}
-                changed={UiState.getTestState(test).modified}
-                selectTest={UiState.selectTest}
-                renameTest={this.props.renameTest}
-                removeTest={() => { this.props.removeTest(test); }}
-                moveSelectionUp={() => { UiState.selectTestByIndex(index - 1); }}
-                moveSelectionDown={() => { UiState.selectTestByIndex(index + 1); }}
-                setSectionFocus={UiState.setSectionFocus}
-              />}
+            <ReactCursorPosition>
+              {this.props.suite ?
+                <DraggableTest
+                  className={PlaybackState.testState.get(test.id)}
+                  test={test}
+                  suite={this.props.suite}
+                  selected={UiState.selectedTest.test && test.id === UiState.selectedTest.test.id && this.props.suite.id === (UiState.selectedTest.suite ? UiState.selectedTest.suite.id : undefined)}
+                  changed={UiState.getTestState(test).modified}
+                  selectTest={UiState.selectTest}
+                  dragInProgress={UiState.dragInProgress}
+                  setDrag={UiState.setDrag}
+                  removeTest={() => { this.props.removeTest(test); }}
+                  moveSelectionUp={() => { UiState.selectTestByIndex(index - 1, this.props.suite); }}
+                  moveSelectionDown={() => { UiState.selectTestByIndex(index + 1, this.props.suite); }}
+                  setSectionFocus={UiState.setSectionFocus}
+                /> :
+                <Test
+                  className={PlaybackState.testState.get(test.id)}
+                  index={index}
+                  test={test}
+                  selected={UiState.selectedTest.test && test.id === UiState.selectedTest.test.id}
+                  changed={UiState.getTestState(test).modified}
+                  selectTest={UiState.selectTest}
+                  renameTest={this.props.renameTest}
+                  removeTest={() => { this.props.removeTest(test); }}
+                  moveSelectionUp={() => { UiState.selectTestByIndex(index - 1); }}
+                  moveSelectionDown={() => { UiState.selectTestByIndex(index + 1); }}
+                  setSectionFocus={UiState.setSectionFocus}
+                  onContextMenu={() => { this.props.onContextMenu(index); }}
+                />}
+              </ReactCursorPosition>
           </li>
         ))}
       </ul>

--- a/src/neo/components/TestRow/index.jsx
+++ b/src/neo/components/TestRow/index.jsx
@@ -26,7 +26,7 @@ import ListMenu, { ListMenuItem, ListMenuSeparator } from "../ListMenu";
 import MultilineEllipsis from "../MultilineEllipsis";
 import { observer } from "mobx-react";
 import UiState from "../../stores/view/UiState";
-import ReactDOM from "react-dom";
+import { findDOMNode } from "react-dom";
 import ContextMenu from "../ContextMenu";
 import "./style.css";
 
@@ -127,14 +127,16 @@ export default class TestRow extends React.Component {
     clearAllCommands: PropTypes.func,
     moveSelectionUp: PropTypes.func,
     moveSelectionDown: PropTypes.func,
-    setSectionFocus: PropTypes.func
+    setSectionFocus: PropTypes.func,
+    onContextMenu: PropTypes.func,
+    position: PropTypes.any
   };
   componentDidMount() {
     if (this.props.selected) {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: ReactDOM.findDOMNode(this).parentElement.getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()});
     }
   }
   componentDidUpdate(prevProps) {
@@ -143,7 +145,7 @@ export default class TestRow extends React.Component {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: ReactDOM.findDOMNode(this).parentElement.getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()});
     }
   }
   componentWillUnmount() {
@@ -183,19 +185,19 @@ export default class TestRow extends React.Component {
     }
   }  
   render() {    
-      const menuList =<div>            
-        <ListMenuItem label={parse("x", { primaryKey: true})} onClick={() => {this.props.copyToClipboard(); this.props.remove();}}>Cut</ListMenuItem>
-        <ListMenuItem label={parse("c", { primaryKey: true})} onClick={this.props.copyToClipboard}>Copy</ListMenuItem>
-        <ListMenuItem label={parse("v", { primaryKey: true})} onClick={this.paste}>Paste</ListMenuItem>
-        <ListMenuItem label="Del" onClick={this.props.remove}>Delete</ListMenuItem>
-        <ListMenuSeparator />
-        <ListMenuItem onClick={() => { this.props.insertCommand(); }}>Insert new command</ListMenuItem>
-        <ListMenuSeparator />
-        <ListMenuItem onClick={this.props.clearAllCommands}>Clear all</ListMenuItem>
-        <ListMenuSeparator />
-        <ListMenuItem label="S" onClick={this.props.startPlayingHere}>Play from here</ListMenuItem>
-        <ListMenuItem label="X" onClick={this.props.executeCommand}>Execute this command</ListMenuItem>           
-      </div>
+    const menuList =<div>            
+      <ListMenuItem label={parse("x", { primaryKey: true})} onClick={() => {this.props.copyToClipboard(); this.props.remove();}}>Cut</ListMenuItem>
+      <ListMenuItem label={parse("c", { primaryKey: true})} onClick={this.props.copyToClipboard}>Copy</ListMenuItem>
+      <ListMenuItem label={parse("v", { primaryKey: true})} onClick={this.paste}>Paste</ListMenuItem>
+      <ListMenuItem label="Del" onClick={this.props.remove}>Delete</ListMenuItem>
+      <ListMenuSeparator />
+      <ListMenuItem onClick={() => { this.props.insertCommand(); }}>Insert new command</ListMenuItem>
+      <ListMenuSeparator />
+      <ListMenuItem onClick={this.props.clearAllCommands}>Clear all</ListMenuItem>
+      <ListMenuSeparator />
+      <ListMenuItem label="S" onClick={this.props.startPlayingHere}>Play from here</ListMenuItem>
+      <ListMenuItem label="X" onClick={this.props.executeCommand}>Execute this command</ListMenuItem>           
+    </div>;
 
     const rendered = <tr
       ref={node => {return(this.node = node || this.node);}}
@@ -219,12 +221,12 @@ export default class TestRow extends React.Component {
         <div>
           { this.props.swapCommands ? 
             <ListMenu width={300} padding={-5} opener={<MoreButton /> }>
-              {menuList}
+             {menuList}
             </ListMenu>: null }
-            <ContextMenu width={300} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
+          <ContextMenu width={300} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
             isOpen ={UiState.isContextOpenEditor[this.props.index]} position={this.props.position}>
-              {menuList}
-            </ ContextMenu>            
+            {menuList}
+          </ ContextMenu>
         </div>
       </td>
     </tr>;

--- a/src/neo/components/TestRow/index.jsx
+++ b/src/neo/components/TestRow/index.jsx
@@ -134,7 +134,7 @@ export default class TestRow extends React.Component {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: ReactDOM.findDOMNode(this).parentElement.getBoundingClientRect()});
     }
   }
   componentDidUpdate(prevProps) {
@@ -143,7 +143,7 @@ export default class TestRow extends React.Component {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
+      this.setState({rect: ReactDOM.findDOMNode(this).parentElement.getBoundingClientRect()});
     }
   }
   componentWillUnmount() {

--- a/src/neo/components/TestRow/index.jsx
+++ b/src/neo/components/TestRow/index.jsx
@@ -221,8 +221,8 @@ export default class TestRow extends React.Component {
             <ListMenu width={300} padding={-5} opener={<MoreButton /> }>
               {menuList}
             </ListMenu>: null }
-            <ContextMenu width={300} padding={-5} index={this.props.index} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
-            isOpen ={UiState.isContextOpen[this.props.index]} position={this.props.position}>
+            <ContextMenu width={300} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
+            isOpen ={UiState.isContextOpenEditor[this.props.index]} position={this.props.position}>
               {menuList}
             </ ContextMenu>            
         </div>

--- a/src/neo/components/TestRow/index.jsx
+++ b/src/neo/components/TestRow/index.jsx
@@ -136,7 +136,7 @@ export default class TestRow extends React.Component {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()}); // eslint-disable-line react/no-find-dom-node
     }
   }
   componentDidUpdate(prevProps) {
@@ -145,7 +145,7 @@ export default class TestRow extends React.Component {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
       });      
-      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()});
+      this.setState({rect: findDOMNode(this).parentElement.getBoundingClientRect()}); // eslint-disable-line react/no-find-dom-node
     }
   }
   componentWillUnmount() {
@@ -221,7 +221,7 @@ export default class TestRow extends React.Component {
         <div>
           { this.props.swapCommands ? 
             <ListMenu width={300} padding={-5} opener={<MoreButton /> }>
-             {menuList}
+              {menuList}
             </ListMenu>: null }
           <ContextMenu width={300} padding={-5} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
             isOpen ={UiState.isContextOpenEditor[this.props.index]} position={this.props.position}>

--- a/src/neo/components/TestRow/index.jsx
+++ b/src/neo/components/TestRow/index.jsx
@@ -24,6 +24,10 @@ import CommandName from "../CommandName";
 import MoreButton from "../ActionButtons/More";
 import ListMenu, { ListMenuItem, ListMenuSeparator } from "../ListMenu";
 import MultilineEllipsis from "../MultilineEllipsis";
+import { observer } from "mobx-react";
+import UiState from "../../stores/view/UiState";
+import ReactDOM from "react-dom";
+import ContextMenu from "../ContextMenu";
 import "./style.css";
 
 export const Type = "command";
@@ -91,10 +95,12 @@ const commandTarget = {
   connectDragSource: connect.dragSource(),
   isDragging: monitor.isDragging()
 }))
+@observer
 export default class TestRow extends React.Component {
   constructor(props) {
     super(props);
-    this.paste = this.paste.bind(this);
+    this.paste = this.paste.bind(this);    
+    this.state ={};
   }
   static propTypes = {
     id: PropTypes.string,
@@ -127,7 +133,8 @@ export default class TestRow extends React.Component {
     if (this.props.selected) {
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
-      });
+      });      
+      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentDidUpdate(prevProps) {
@@ -135,7 +142,8 @@ export default class TestRow extends React.Component {
       this.node.focus();
       this.props.setSectionFocus("editor", () => {
         this.node.focus();
-      });
+      });      
+      this.setState({rect: ReactDOM.findDOMNode(this).getBoundingClientRect()});
     }
   }
   componentWillUnmount() {
@@ -173,12 +181,27 @@ export default class TestRow extends React.Component {
     if (this.props.clipboard && this.props.clipboard.constructor.name === "Command") {
       this.props.addCommand(this.props.clipboard);
     }
-  }
-  render() {
+  }  
+  render() {    
+      const menuList =<div>            
+        <ListMenuItem label={parse("x", { primaryKey: true})} onClick={() => {this.props.copyToClipboard(); this.props.remove();}}>Cut</ListMenuItem>
+        <ListMenuItem label={parse("c", { primaryKey: true})} onClick={this.props.copyToClipboard}>Copy</ListMenuItem>
+        <ListMenuItem label={parse("v", { primaryKey: true})} onClick={this.paste}>Paste</ListMenuItem>
+        <ListMenuItem label="Del" onClick={this.props.remove}>Delete</ListMenuItem>
+        <ListMenuSeparator />
+        <ListMenuItem onClick={() => { this.props.insertCommand(); }}>Insert new command</ListMenuItem>
+        <ListMenuSeparator />
+        <ListMenuItem onClick={this.props.clearAllCommands}>Clear all</ListMenuItem>
+        <ListMenuSeparator />
+        <ListMenuItem label="S" onClick={this.props.startPlayingHere}>Play from here</ListMenuItem>
+        <ListMenuItem label="X" onClick={this.props.executeCommand}>Execute this command</ListMenuItem>           
+      </div>
+
     const rendered = <tr
       ref={node => {return(this.node = node || this.node);}}
       className={classNames(this.props.className, {"selected": this.props.selected}, {"dragging": this.props.dragInProgress})}
       tabIndex={this.props.selected ? "0" : "-1"}
+      onContextMenu={this.props.onContextMenu}
       onClick={this.props.onClick}
       onDoubleClick={this.props.executeCommand}
       onKeyDown={this.handleKeyDown.bind(this)}
@@ -195,21 +218,13 @@ export default class TestRow extends React.Component {
       <td className="buttons">
         <div>
           { this.props.swapCommands ? 
-            <ListMenu width={300} padding={-5} opener={
-              <MoreButton />
-            }>
-              <ListMenuItem label={parse("x", { primaryKey: true})} onClick={() => {this.props.copyToClipboard(); this.props.remove();}}>Cut</ListMenuItem>
-              <ListMenuItem label={parse("c", { primaryKey: true})} onClick={this.props.copyToClipboard}>Copy</ListMenuItem>
-              <ListMenuItem label={parse("v", { primaryKey: true})} onClick={this.paste}>Paste</ListMenuItem>
-              <ListMenuItem label="Del" onClick={this.props.remove}>Delete</ListMenuItem>
-              <ListMenuSeparator />
-              <ListMenuItem onClick={() => { this.props.insertCommand(); }}>Insert new command</ListMenuItem>
-              <ListMenuSeparator />
-              <ListMenuItem onClick={this.props.clearAllCommands}>Clear all</ListMenuItem>
-              <ListMenuSeparator />
-              <ListMenuItem label="S" onClick={this.props.startPlayingHere}>Play from here</ListMenuItem>
-              <ListMenuItem label="X" onClick={this.props.executeCommand}>Execute this command</ListMenuItem>
-            </ListMenu> : null }
+            <ListMenu width={300} padding={-5} opener={<MoreButton /> }>
+              {menuList}
+            </ListMenu>: null }
+            <ContextMenu width={300} padding={-5} index={this.props.index} onContextMenu={this.props.onContextMenu} rect={this.state.rect}
+            isOpen ={UiState.isContextOpen[this.props.index]} position={this.props.position}>
+              {menuList}
+            </ ContextMenu>            
         </div>
       </td>
     </tr>;

--- a/src/neo/components/TestTable/index.jsx
+++ b/src/neo/components/TestTable/index.jsx
@@ -23,9 +23,9 @@ import classNames from "classnames";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
 import TestRow from "../TestRow";
+import ReactCursorPosition from "react-cursor-position";
 import "./style.css";
 
-import ReactCursorPosition from 'react-cursor-position';
 
 @observer
 export default class TestTable extends React.Component {

--- a/src/neo/components/TestTable/index.jsx
+++ b/src/neo/components/TestTable/index.jsx
@@ -25,6 +25,8 @@ import PlaybackState from "../../stores/view/PlaybackState";
 import TestRow from "../TestRow";
 import "./style.css";
 
+import ReactCursorPosition from 'react-cursor-position';
+
 @observer
 export default class TestTable extends React.Component {
   static propTypes = {
@@ -36,8 +38,18 @@ export default class TestTable extends React.Component {
     swapCommands: PropTypes.func,
     clearAllCommands: PropTypes.func
   };
+  componentDidMount() {
+    document.addEventListener('contextmenu', this.handleContextMenu);       
+  };
+  componentWillUnmount() {
+    document.removeEventListener('contextmenu', this.handleContextMenu);
+  };  
+  handleContextMenu(e){         
+    e.preventDefault();           
+  } 
   render() {
     return ([
+      
       <div key="header" className="test-table test-table-header">
         <table>
           <thead>
@@ -49,52 +61,61 @@ export default class TestTable extends React.Component {
           </thead>
         </table>
       </div>,
-      <div key="body" className="test-table test-table-body">
+                  
+      <div key="body" className="test-table test-table-body">        
         <table>
           <tbody>
-            { this.props.commands ? this.props.commands.map((command, index) => (
-              <TestRow
-                key={command.id}
-                id={command.id}
-                className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}
-                selected={this.props.selectedCommand === command.id}
-                index={index}
-                command={command.command}
-                target={command.target}
-                value={command.value}
-                dragInProgress={UiState.dragInProgress}
-                onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
-                startPlayingHere={() => { PlaybackState.startPlaying(command); }}
-                executeCommand={() => { PlaybackState.playCommand(command); }}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
-                moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
-                insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
-                remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
-                swapCommands={this.props.swapCommands}
-                setDrag={UiState.setDrag}
-                clipboard={UiState.clipboard}
-                copyToClipboard={() => { UiState.copyToClipboard(command); }}
-                clearAllCommands={this.props.clearAllCommands}
-                setSectionFocus={UiState.setSectionFocus}
-              />
-            )).concat(
-              <TestRow
-                id={UiState.pristineCommand.id}
-                key={UiState.selectedTest.test.id}
-                selected={this.props.selectedCommand === UiState.pristineCommand.id}
-                command={UiState.pristineCommand.command}
-                target={UiState.pristineCommand.target}
-                value={UiState.pristineCommand.value}
-                onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
-                clipboard={UiState.clipboard}
-                setSectionFocus={UiState.setSectionFocus}
-              />) : null }
+            { this.props.commands ? this.props.commands.map((command, index) => {                            
+              return <ReactCursorPosition key={ "cursor"+command.id }>
+                <TestRow
+                  key={command.id}
+                  id={command.id}
+                  ref={command.id}
+                  className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}                  
+                  selected={this.props.selectedCommand === command.id}
+                  index={index}
+                  command={command.command}
+                  target={command.target}
+                  value={command.value}
+                  dragInProgress={UiState.dragInProgress}
+                  onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
+                  startPlayingHere={() => { PlaybackState.startPlaying(command); }}
+                  executeCommand={() => { PlaybackState.playCommand(command); }}
+                  moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
+                  moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
+                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
+                  insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
+                  remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
+                  swapCommands={this.props.swapCommands}
+                  setDrag={UiState.setDrag}
+                  clipboard={UiState.clipboard}
+                  copyToClipboard={() => { UiState.copyToClipboard(command); }}
+                  clearAllCommands={this.props.clearAllCommands}
+                  setSectionFocus={UiState.setSectionFocus}
+                  onContextMenu={() => { this.props.onContextMenu(index); }}
+                />  
+              </ReactCursorPosition>            
+            }).concat(
+              <ReactCursorPosition key={ "cursor" + UiState.pristineCommand.id }>
+                <TestRow
+                  id={UiState.pristineCommand.id}
+                  key={UiState.selectedTest.test.id}
+                  ref={UiState.selectedTest.test.id}
+                  selected={this.props.selectedCommand === UiState.pristineCommand.id}
+                  command={UiState.pristineCommand.command}
+                  target={UiState.pristineCommand.target}
+                  value={UiState.pristineCommand.value}
+                  onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
+                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
+                  moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
+                  clipboard={UiState.clipboard}
+                  setSectionFocus={UiState.setSectionFocus}
+                />
+              </ReactCursorPosition>
+              ) : null }              
           </tbody>
         </table>
-      </div>
+      </div>                
     ]);
   }
 }

--- a/src/neo/components/TestTable/index.jsx
+++ b/src/neo/components/TestTable/index.jsx
@@ -39,11 +39,11 @@ export default class TestTable extends React.Component {
     clearAllCommands: PropTypes.func
   };
   componentDidMount() {
-    document.addEventListener('contextmenu', this.handleContextMenu);
-  };
+    document.addEventListener("contextmenu", this.handleContextMenu);
+  }
   componentWillUnmount() {
-    document.removeEventListener('contextmenu', this.handleContextMenu);
-  };
+    document.removeEventListener("contextmenu", this.handleContextMenu);
+  }
   handleContextMenu(e){         
     e.preventDefault();           
   } 
@@ -70,58 +70,69 @@ export default class TestTable extends React.Component {
 
 @observer
 class TestRowContainer extends React.Component {
+  static propTypes = {
+    commands: MobxPropTypes.arrayOrObservableArray,
+    selectedCommand: PropTypes.string,
+    selectCommand: PropTypes.func,
+    addCommand: PropTypes.func,
+    removeCommand: PropTypes.func,
+    swapCommands: PropTypes.func,
+    clearAllCommands: PropTypes.func,
+    onContextMenu: PropTypes.func,
+    position: PropTypes.any
+  };
   render() {       
     return([
       <table key="table">
         <tbody key="tbody">
           { this.props.commands ? this.props.commands.map((command, index) => (                                       
-              <TestRow
-                key={command.id}
-                id={command.id}
-                ref={command.id}
-                className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}                  
-                selected={this.props.selectedCommand === command.id}
-                index={index}
-                command={command.command}
-                target={command.target}
-                value={command.value}
-                dragInProgress={UiState.dragInProgress}
-                onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
-                startPlayingHere={() => { PlaybackState.startPlaying(command); }}
-                executeCommand={() => { PlaybackState.playCommand(command); }}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
-                moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
-                insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
-                remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
-                swapCommands={this.props.swapCommands}
-                setDrag={UiState.setDrag}
-                clipboard={UiState.clipboard}
-                copyToClipboard={() => { UiState.copyToClipboard(command); }}
-                clearAllCommands={this.props.clearAllCommands}
-                setSectionFocus={UiState.setSectionFocus}
-                onContextMenu={() => { this.props.onContextMenu(index); }}
-                position={this.props.position}                
-              />                
+            <TestRow
+              key={command.id}
+              id={command.id}
+              ref={command.id}
+              className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}                  
+              selected={this.props.selectedCommand === command.id}
+              index={index}
+              command={command.command}
+              target={command.target}
+              value={command.value}
+              dragInProgress={UiState.dragInProgress}
+              onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
+              startPlayingHere={() => { PlaybackState.startPlaying(command); }}
+              executeCommand={() => { PlaybackState.playCommand(command); }}
+              moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
+              moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
+              addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
+              insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
+              remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
+              swapCommands={this.props.swapCommands}
+              setDrag={UiState.setDrag}
+              clipboard={UiState.clipboard}
+              copyToClipboard={() => { UiState.copyToClipboard(command); }}
+              clearAllCommands={this.props.clearAllCommands}
+              setSectionFocus={UiState.setSectionFocus}
+              onContextMenu={() => { this.props.onContextMenu(index); }}
+              position={this.props.position}                
+            />                
           )).concat(              
-              <TestRow
-                id={UiState.pristineCommand.id}
-                key={UiState.selectedTest.test.id}
-                ref={UiState.selectedTest.test.id}
-                selected={this.props.selectedCommand === UiState.pristineCommand.id}
-                command={UiState.pristineCommand.command}
-                target={UiState.pristineCommand.target}
-                value={UiState.pristineCommand.value}
-                onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
-                clipboard={UiState.clipboard}
-                setSectionFocus={UiState.setSectionFocus}
-                position={this.props.position}                
-              />              
-            ) : null }              
+            <TestRow
+              id={UiState.pristineCommand.id}
+              key={UiState.selectedTest.test.id}
+              ref={UiState.selectedTest.test.id}
+              selected={this.props.selectedCommand === UiState.pristineCommand.id}
+              command={UiState.pristineCommand.command}
+              target={UiState.pristineCommand.target}
+              value={UiState.pristineCommand.value}
+              onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
+              addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
+              moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
+              clipboard={UiState.clipboard}
+              setSectionFocus={UiState.setSectionFocus}
+              position={this.props.position}                
+            />              
+          ) : null }              
         </tbody>
       </table>    
-    ])    
+    ]);
   }
 }

--- a/src/neo/components/TestTable/index.jsx
+++ b/src/neo/components/TestTable/index.jsx
@@ -39,11 +39,11 @@ export default class TestTable extends React.Component {
     clearAllCommands: PropTypes.func
   };
   componentDidMount() {
-    document.addEventListener('contextmenu', this.handleContextMenu);       
+    document.addEventListener('contextmenu', this.handleContextMenu);
   };
   componentWillUnmount() {
     document.removeEventListener('contextmenu', this.handleContextMenu);
-  };  
+  };
   handleContextMenu(e){         
     e.preventDefault();           
   } 
@@ -61,61 +61,67 @@ export default class TestTable extends React.Component {
           </thead>
         </table>
       </div>,
-                  
-      <div key="body" className="test-table test-table-body">        
-        <table>
-          <tbody>
-            { this.props.commands ? this.props.commands.map((command, index) => {                            
-              return <ReactCursorPosition key={ "cursor"+command.id }>
-                <TestRow
-                  key={command.id}
-                  id={command.id}
-                  ref={command.id}
-                  className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}                  
-                  selected={this.props.selectedCommand === command.id}
-                  index={index}
-                  command={command.command}
-                  target={command.target}
-                  value={command.value}
-                  dragInProgress={UiState.dragInProgress}
-                  onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
-                  startPlayingHere={() => { PlaybackState.startPlaying(command); }}
-                  executeCommand={() => { PlaybackState.playCommand(command); }}
-                  moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
-                  moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
-                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
-                  insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
-                  remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
-                  swapCommands={this.props.swapCommands}
-                  setDrag={UiState.setDrag}
-                  clipboard={UiState.clipboard}
-                  copyToClipboard={() => { UiState.copyToClipboard(command); }}
-                  clearAllCommands={this.props.clearAllCommands}
-                  setSectionFocus={UiState.setSectionFocus}
-                  onContextMenu={() => { this.props.onContextMenu(index); }}
-                />  
-              </ReactCursorPosition>            
-            }).concat(
-              <ReactCursorPosition key={ "cursor" + UiState.pristineCommand.id }>
-                <TestRow
-                  id={UiState.pristineCommand.id}
-                  key={UiState.selectedTest.test.id}
-                  ref={UiState.selectedTest.test.id}
-                  selected={this.props.selectedCommand === UiState.pristineCommand.id}
-                  command={UiState.pristineCommand.command}
-                  target={UiState.pristineCommand.target}
-                  value={UiState.pristineCommand.value}
-                  onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
-                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
-                  moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
-                  clipboard={UiState.clipboard}
-                  setSectionFocus={UiState.setSectionFocus}
-                />
-              </ReactCursorPosition>
-              ) : null }              
-          </tbody>
-        </table>
-      </div>                
+      <ReactCursorPosition key="body" className="test-table test-table-body">                  
+        <TestRowContainer {...this.props}/>
+      </ReactCursorPosition>
     ]);
+  }
+}
+
+@observer
+class TestRowContainer extends React.Component {
+  render() {       
+    return([
+      <table key="table">
+        <tbody key="tbody">
+          { this.props.commands ? this.props.commands.map((command, index) => (                                       
+              <TestRow
+                key={command.id}
+                id={command.id}
+                ref={command.id}
+                className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}                  
+                selected={this.props.selectedCommand === command.id}
+                index={index}
+                command={command.command}
+                target={command.target}
+                value={command.value}
+                dragInProgress={UiState.dragInProgress}
+                onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
+                startPlayingHere={() => { PlaybackState.startPlaying(command); }}
+                executeCommand={() => { PlaybackState.playCommand(command); }}
+                moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
+                moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
+                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
+                insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
+                remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
+                swapCommands={this.props.swapCommands}
+                setDrag={UiState.setDrag}
+                clipboard={UiState.clipboard}
+                copyToClipboard={() => { UiState.copyToClipboard(command); }}
+                clearAllCommands={this.props.clearAllCommands}
+                setSectionFocus={UiState.setSectionFocus}
+                onContextMenu={() => { this.props.onContextMenu(index); }}
+                position={this.props.position}                
+              />                
+          )).concat(              
+              <TestRow
+                id={UiState.pristineCommand.id}
+                key={UiState.selectedTest.test.id}
+                ref={UiState.selectedTest.test.id}
+                selected={this.props.selectedCommand === UiState.pristineCommand.id}
+                command={UiState.pristineCommand.command}
+                target={UiState.pristineCommand.target}
+                value={UiState.pristineCommand.value}
+                onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
+                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
+                moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
+                clipboard={UiState.clipboard}
+                setSectionFocus={UiState.setSectionFocus}
+                position={this.props.position}                
+              />              
+            ) : null }              
+        </tbody>
+      </table>    
+    ])    
   }
 }

--- a/src/neo/containers/Editor/index.jsx
+++ b/src/neo/containers/Editor/index.jsx
@@ -85,6 +85,7 @@ import "./style.css";
           removeCommand={this.removeCommand}
           clearAllCommands={this.props.test ? this.props.test.clearAllCommands : null}
           swapCommands={this.props.test ? this.props.test.swapCommands : null}
+          onContextMenu={UiState.onContextMenu}    
         />
         <CommandForm
           command={UiState.selectedCommand}

--- a/src/neo/containers/Editor/index.jsx
+++ b/src/neo/containers/Editor/index.jsx
@@ -85,7 +85,7 @@ import "./style.css";
           removeCommand={this.removeCommand}
           clearAllCommands={this.props.test ? this.props.test.clearAllCommands : null}
           swapCommands={this.props.test ? this.props.test.swapCommands : null}
-          onContextMenu={UiState.onContextMenu}    
+          onContextMenu={UiState.onContextMenuEditor}
         />
         <CommandForm
           command={UiState.selectedCommand}

--- a/src/neo/containers/Navigation/index.jsx
+++ b/src/neo/containers/Navigation/index.jsx
@@ -73,7 +73,7 @@ import "./style.css";
         <SearchBar value={UiState.filterTerm} filter={UiState.changeFilter} />
         <Provider renameTest={ModalState.renameTest}>
           { this.state.showTests
-            ? <TestList tests={this.props.tests} removeTest={ModalState.deleteTest} />
+            ? <TestList tests={this.props.tests} removeTest={ModalState.deleteTest} onContextMenu={UiState.onContextMenuNavigation} />
             : <SuiteList suites={this.props.suites} rename={ModalState.renameSuite} selectTests={ModalState.editSuite} removeSuite={ModalState.deleteSuite} moveTest={this.props.moveTest} /> }
         </Provider>
         <Runs

--- a/src/neo/stores/view/PlaybackState.js
+++ b/src/neo/stores/view/PlaybackState.js
@@ -81,11 +81,12 @@ class PlaybackState {
     this.currentRunningTest = UiState.selectedTest.test;
     this.runningQueue = [command];
     this.isPlaying = true;
-	//reset to false
-    for(var i = 0; i <= UiState.isContextOpenEditor.length; i++){
+    //reset to false
+    let i = 0;
+    for(i = 0; i <= UiState.isContextOpenEditor.length; i++){
       this.isContextOpenEditor[i]=false;
     }
-    for(var i = 0; i <= UiState.isContextOpenNavigation.length; i++){
+    for(i = 0; i <= UiState.isContextOpenNavigation.length; i++){
       this.isContextOpenNavigation[i]=false;
     }
   }

--- a/src/neo/stores/view/PlaybackState.js
+++ b/src/neo/stores/view/PlaybackState.js
@@ -81,6 +81,7 @@ class PlaybackState {
     this.currentRunningTest = UiState.selectedTest.test;
     this.runningQueue = [command];
     this.isPlaying = true;
+    UiState.isContextOpen={};        
   }
 
   @action.bound playNext() {

--- a/src/neo/stores/view/PlaybackState.js
+++ b/src/neo/stores/view/PlaybackState.js
@@ -81,7 +81,13 @@ class PlaybackState {
     this.currentRunningTest = UiState.selectedTest.test;
     this.runningQueue = [command];
     this.isPlaying = true;
-    UiState.isContextOpenEditor={};
+	//reset to false
+    for(var i = 0; i <= UiState.isContextOpenEditor.length; i++){
+      this.isContextOpenEditor[i]=false;
+    }
+    for(var i = 0; i <= UiState.isContextOpenNavigation.length; i++){
+      this.isContextOpenNavigation[i]=false;
+    }
   }
 
   @action.bound playNext() {

--- a/src/neo/stores/view/PlaybackState.js
+++ b/src/neo/stores/view/PlaybackState.js
@@ -81,7 +81,7 @@ class PlaybackState {
     this.currentRunningTest = UiState.selectedTest.test;
     this.runningQueue = [command];
     this.isPlaying = true;
-    UiState.isContextOpen={};        
+    UiState.isContextOpenEditor={};
   }
 
   @action.bound playNext() {

--- a/src/neo/stores/view/UiState.js
+++ b/src/neo/stores/view/UiState.js
@@ -40,7 +40,8 @@ class UiState {
   @observable navigationHover = false;
   @observable navigationDragging = false;
   @observable pristineCommand = new Command();
-  @observable lastFocus = {};
+  @observable lastFocus = {};  
+  @observable isContextOpen = [];
 
   constructor() {
     this.suiteStates = {};
@@ -97,6 +98,9 @@ class UiState {
       } else {
         this.selectCommand(undefined);
       }
+      for(var i = 0; i <= test.commands.length; i++){
+        this.isContextOpen[i]=false;
+      }
     }
     this.selectedTest = { test, suite };
   }
@@ -127,10 +131,10 @@ class UiState {
   }
 
   @action.bound selectCommand(command) {
-    this.selectedCommand = command;
+    this.selectedCommand = command;         
   }
 
-  @action.bound selectCommandByIndex(index) {
+  @action.bound selectCommandByIndex(index) {    
     const { test } = this.selectedTest; 
     if (index >= 0 && index < test.commands.length) {
       this.selectCommand(test.commands[index]);
@@ -266,6 +270,10 @@ class UiState {
       state.modified = false;
     });
     this._project.modified = false;
+  }
+
+  @action.bound onContextMenu(index) {  
+      this.isContextOpen[index] = !this.isContextOpen[index];      
   }
 }
 

--- a/src/neo/stores/view/UiState.js
+++ b/src/neo/stores/view/UiState.js
@@ -21,7 +21,6 @@ import SuiteState from "./SuiteState";
 import TestState from "./TestState";
 import PlaybackState from "./PlaybackState";
 import Command from "../../models/Command";
-import { findDOMNode } from "react-dom";
 
 class UiState {
   @observable selectedTest = {};
@@ -100,10 +99,11 @@ class UiState {
       } else {
         this.selectCommand(undefined);
       }
-      for(var i = 0; i <= test.commands.length; i++){
+      let i = 0;
+      for(i = 0; i <= test.commands.length; i++){
         this.isContextOpenEditor[i]=false;
       }
-      for(var i = 0; i <= this._project.tests.length; i++){
+      for(i = 0; i <= this._project.tests.length; i++){
         this.isContextOpenNavigation[i]=false;
       }
     }
@@ -278,7 +278,7 @@ class UiState {
   }
 
   @action.bound onContextMenuEditor(index) {
-    if((document.getElementsByClassName('ReactModal__Body--open').length) > 0 ){
+    if((document.getElementsByClassName("ReactModal__Body--open").length) > 0 ){
       this.isContextOpenEditor[index] = false;
     }else{
       this.isContextOpenEditor[index] = true;
@@ -286,7 +286,7 @@ class UiState {
   }
 
   @action.bound onContextMenuNavigation(index) {
-    if((document.getElementsByClassName('ReactModal__Body--open').length) > 0){
+    if((document.getElementsByClassName("ReactModal__Body--open").length) > 0){
       this.isContextOpenNavigation[index] = false;
     }else{
       this.isContextOpenNavigation[index] = true;

--- a/src/neo/stores/view/UiState.js
+++ b/src/neo/stores/view/UiState.js
@@ -21,6 +21,7 @@ import SuiteState from "./SuiteState";
 import TestState from "./TestState";
 import PlaybackState from "./PlaybackState";
 import Command from "../../models/Command";
+import { findDOMNode } from "react-dom";
 
 class UiState {
   @observable selectedTest = {};
@@ -41,7 +42,8 @@ class UiState {
   @observable navigationDragging = false;
   @observable pristineCommand = new Command();
   @observable lastFocus = {};  
-  @observable isContextOpen = [];
+  @observable isContextOpenEditor = [];
+  @observable isContextOpenNavigation= [];
 
   constructor() {
     this.suiteStates = {};
@@ -64,6 +66,9 @@ class UiState {
   }
 
   @computed get filteredTests() {
+    for(var i = 0; i <= this._project.tests.length; i++){
+      this.isContextOpenNavigation[i]=false;
+    }
     return this._project.tests.filter(this.filterFunction);
   }
 
@@ -99,7 +104,7 @@ class UiState {
         this.selectCommand(undefined);
       }
       for(var i = 0; i <= test.commands.length; i++){
-        this.isContextOpen[i]=false;
+        this.isContextOpenEditor[i]=false;
       }
     }
     this.selectedTest = { test, suite };
@@ -256,7 +261,7 @@ class UiState {
     this.dragInProgress = false;
     this.clipboard = null;
     this.isRecording = false;
-    this.suiteStates = {};
+    this.suiteStates = {}
     this.clearTestStates();
   }
 
@@ -272,8 +277,19 @@ class UiState {
     this._project.modified = false;
   }
 
-  @action.bound onContextMenu(index) {  
-      this.isContextOpen[index] = !this.isContextOpen[index];      
+  @action.bound onContextMenuEditor(index) {
+      if((document.getElementsByClassName('ReactModal__Body--open').length) > 0){
+        this.isContextOpenEditor[index] = false;
+      }else{
+        this.isContextOpenEditor[index] = true;
+      }
+  }
+  @action.bound onContextMenuNavigation(index) {
+    if((document.getElementsByClassName('ReactModal__Body--open').length) > 0){
+      this.isContextOpenNavigation[index] = false;
+    }else{
+      this.isContextOpenNavigation[index] = true;
+    }
   }
 }
 

--- a/src/neo/stores/view/UiState.js
+++ b/src/neo/stores/view/UiState.js
@@ -66,9 +66,6 @@ class UiState {
   }
 
   @computed get filteredTests() {
-    for(var i = 0; i <= this._project.tests.length; i++){
-      this.isContextOpenNavigation[i]=false;
-    }
     return this._project.tests.filter(this.filterFunction);
   }
 
@@ -105,6 +102,9 @@ class UiState {
       }
       for(var i = 0; i <= test.commands.length; i++){
         this.isContextOpenEditor[i]=false;
+      }
+      for(var i = 0; i <= this._project.tests.length; i++){
+        this.isContextOpenNavigation[i]=false;
       }
     }
     this.selectedTest = { test, suite };
@@ -261,7 +261,7 @@ class UiState {
     this.dragInProgress = false;
     this.clipboard = null;
     this.isRecording = false;
-    this.suiteStates = {}
+    this.suiteStates = {};
     this.clearTestStates();
   }
 
@@ -278,12 +278,13 @@ class UiState {
   }
 
   @action.bound onContextMenuEditor(index) {
-      if((document.getElementsByClassName('ReactModal__Body--open').length) > 0){
-        this.isContextOpenEditor[index] = false;
-      }else{
-        this.isContextOpenEditor[index] = true;
-      }
+    if((document.getElementsByClassName('ReactModal__Body--open').length) > 0 ){
+      this.isContextOpenEditor[index] = false;
+    }else{
+      this.isContextOpenEditor[index] = true;
+    }
   }
+
   @action.bound onContextMenuNavigation(index) {
     if((document.getElementsByClassName('ReactModal__Body--open').length) > 0){
       this.isContextOpenNavigation[index] = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,6 +3876,12 @@ is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
+is-extendable@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
+
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
@@ -3975,7 +3981,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -5199,6 +5205,12 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
+object.omit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-3.0.0.tgz#0e3edc2fce2ba54df5577ff529f6d97bd8a522af"
+  dependencies:
+    is-extendable "^1.0.0"
+
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
@@ -6076,6 +6088,14 @@ react-autocomplete@^1.7.2:
 react-contenteditable@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/react-contenteditable/-/react-contenteditable-2.0.5.tgz#6ec24aea705f1c10a12414676cd36742bf1dcceb"
+
+react-cursor-position@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-cursor-position/-/react-cursor-position-2.3.0.tgz#53b870b5c7ff942f530ae7cbdde332cbd59736b7"
+  dependencies:
+    object-assign "^4.1.1"
+    object.omit "^3.0.0"
+    prop-types "^15.6.0"
 
 react-deep-force-update@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
add context menu on test row and test navigation.
I will try to add menu on suite navigation.
I could not add, because It is little different with others.

and I have changed some code to remove warning.
react-cursor-position is consist of `div `tag.
`div` tag can't be inside `table` tag, so it was appeared `validateDOMNesting` warning.
This is why I have added `TestRowContainer`.