### PR TITLE
WIP: Eliminate gotos when migrating

### DIFF
--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -62,7 +62,7 @@ export function eliminate(procedure) {
     }
   }
 
-  return eliminateLabels(p);
+  return optimize(eliminateLabels(p));
 }
 
 export function transformToConditional(goto) {
@@ -79,6 +79,14 @@ export function transformToConditional(goto) {
       command: "end"
     }
   ]);
+}
+
+function optimize(procedure) {
+  return procedure.filter((statement, i) => {
+    if (isBlock(statement)) return !isBlockEnd(procedure[i + 1]);
+    if (isBlockEnd(statement)) return !isBlock(procedure[i - 1]);
+    return true;
+  });
 }
 
 export function eliminateLabels(procedure) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -54,6 +54,59 @@ export function eliminateGoto(procedure, goto, label) {
   return p;
 }
 
+export function transformOutward(procedure, goto) {
+  const block = findEnclosingBlock(procedure, goto);
+  const end = findBlockClose(procedure, block);
+  const p = [...procedure];
+  if (block !== "if") {
+    // outward loop movement
+  } else {
+    // outward conditional movement
+  }
+  return p;
+}
+
+function findEnclosingBlock(procedure, goto) {
+  // remember to skip the enclosing if
+  for (let i = procedure.indexOf(goto) - 2; i >= 0; i--) {
+    if (isBlock(procedure[i])) return procedure[i];
+  }
+}
+
+function findBlockClose(procedure, block) {
+  let level = 1, index = procedure.indexOf(block);
+  while (level !== 0) {
+    index++;
+    if (isBlock(procedure[index])) {
+      level++;
+    } else if (isBlockEnd(procedure[index])) {
+      level--;
+    }
+  }
+  return procedure[index];
+}
+
+function isBlock(statement) {
+  switch(statement.command) {
+    case "if":
+    case "do":
+    case "while":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isBlockEnd(statement) {
+  switch(statement.command) {
+    case "end":
+    case "endDo":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function isConditionalGoto(procedure, goto) {
   const index = procedure.indexOf(goto);
   return (procedure[index - 1].command === "if" && procedure[index + 1] === "end");

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -37,19 +37,21 @@ export function eliminateLabel(procedure, label) {
 
 export function eliminateGoto(procedure, goto, label) {
   // only for siblings
+  const p = [...procedure];
   const gotoIndex = procedure.indexOf(goto), labelIndex = procedure.indexOf(label);
   if (gotoIndex < labelIndex) {
     // eliminate using conditional
     const ifIndex = gotoIndex - 1;
-    const p = [...procedure];
     p[ifIndex] = Object.assign({...p[ifIndex]}, {target: `!${p[ifIndex].target}`});
     p.splice(labelIndex, 0, { command: "end" });
     p.splice(gotoIndex, 2);
-
-    return p;
   } else {
     // eliminate using do while
+    const ifIndex = gotoIndex - 1;
+    p.splice(ifIndex, 3, { command: "endDo", target: p[ifIndex].target });
+    p.splice(labelIndex, 0, { command: "do" });
   }
+  return p;
 }
 
 function isConditionalGoto(procedure, goto) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -60,10 +60,27 @@ export function transformOutward(procedure, goto) {
   const p = [...procedure];
   if (block !== "if") {
     // outward loop movement
+    transformOutwardLoop(p, goto, block, end);
   } else {
     // outward conditional movement
   }
   return p;
+}
+
+export function transformOutwardLoop(p, goto, block, end) {
+  const ifIndex = p.indexOf(goto) - 1;
+  p.splice(ifIndex, 3,
+    { command: "storeValue", target: p[ifIndex].target, value: goto.target },
+    { command: "if", target: `\${${goto.target}}` },
+    { command: "break" },
+    { command: "end" }
+  );
+  const endIndex = p.indexOf(end);
+  p.splice(endIndex + 1, 0,
+    { command: "if", target: `\${${goto.target}}` },
+    { command: "goto", target: goto.target },
+    { command: "end" }
+  );
 }
 
 function findEnclosingBlock(procedure, goto) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -99,6 +99,46 @@ function transformOutwardConditional(p, goto, block, end) {
   );
 }
 
+export function transformInward(procedure, goto) {
+}
+
+export function lift(procedure, goto, label) {
+  const p = [
+    { command: "storeValue", target: "false", value: goto.target },
+    ...procedure
+  ];
+  const labelIndex = p.indexOf(label);
+  p.splice(labelIndex, 0,
+    {
+      command: "do"
+    },
+    {
+      command: "if",
+      target: `\${${goto.target}}`
+    },
+    {
+      command: "goto",
+      target: goto.target
+    },
+    {
+      command: "end"
+    }
+  );
+  const ifIndex = p.indexOf(goto) - 1;
+  p.splice(ifIndex, 3,
+    {
+      command: "storeValue",
+      target: "condition",
+      value: goto.target
+    },
+    {
+      command: "endDo",
+      target: `\${${goto.target}}`
+    }
+  );
+  return p;
+}
+
 function findEnclosingBlock(procedure, goto) {
   // remember to skip the enclosing if
   for (let i = procedure.indexOf(goto) - 2; i >= 0; i--) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -118,7 +118,7 @@ export function transformOutward(procedure, goto) {
 function transformOutwardLoop(p, goto, block, end) {
   const ifIndex = p.indexOf(goto) - 1;
   p.splice(ifIndex, 3,
-    { command: "storeValue", target: p[ifIndex].target, value: goto.target },
+    { command: "store", target: p[ifIndex].target, value: goto.target },
     { command: "if", target: `\${${goto.target}}` },
     { command: "break" },
     { command: "end" }
@@ -134,7 +134,7 @@ function transformOutwardLoop(p, goto, block, end) {
 function transformOutwardConditional(p, goto, block, end) {
   const ifIndex = p.indexOf(goto) - 1;
   p.splice(ifIndex, 3,
-    { command: "storeValue", target: p[ifIndex].target, value: goto.target },
+    { command: "store", target: p[ifIndex].target, value: goto.target },
     { command: "if", target: `!\${${goto.target}}` }
   );
   const endIndex = p.indexOf(end);
@@ -151,7 +151,7 @@ export function transformInward(procedure, goto) {
 
 export function lift(procedure, goto, label) {
   const p = [
-    { command: "storeValue", target: "false", value: goto.target },
+    { command: "store", target: "false", value: goto.target },
     ...procedure
   ];
   const labelIndex = p.indexOf(label);
@@ -171,7 +171,7 @@ export function lift(procedure, goto, label) {
   const ifIndex = p.indexOf(goto) - 1;
   p.splice(ifIndex, 3,
     {
-      command: "storeValue",
+      command: "store",
       target: "condition",
       value: goto.target
     },

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -62,7 +62,7 @@ export function eliminate(procedure) {
     }
   }
 
-  return p;
+  return eliminateLabels(p);
 }
 
 export function transformToConditional(goto) {
@@ -81,8 +81,8 @@ export function transformToConditional(goto) {
   ]);
 }
 
-export function eliminateLabel(procedure, label) {
-  return procedure.filter(p => p !== label);
+export function eliminateLabels(procedure) {
+  return procedure.filter(s => s.command !== "label");
 }
 
 export function eliminateGoto(procedure, goto, label) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -1,0 +1,32 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export function transformToConditional(goto) {
+  return ([
+    {
+      command: "if",
+      target: goto.command === "gotoIf" ? goto.target : "true"
+    },
+    {
+      command: "goto",
+      target: goto.command === "gotoIf" ? goto.value : goto.target
+    },
+    {
+      command: "end"
+    }
+  ]);
+}

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -15,6 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
+export function eliminate(procedure) {
+  let p = [...procedure];
+
+  // Change all gotos to conditionals
+  const unconditionalGotos = p.filter(statement => (statement.command === "goto" || statement.command === "gotoIf"));
+  unconditionalGotos.forEach(goto => {
+    const index = p.indexOf(goto);
+    p.splice(index, 1, transformToConditional(goto));
+  });
+
+  const labels = p.filter(statement => statement.command === "label");
+  const gotos = p.filter(statement => statement.command === "goto");
+
+  // start eliminating
+  while (gotos.length) {
+    const goto = gotos[0];
+    const label = findMatchingLabel(labels, goto);
+
+    // Make goto and label directly related
+
+    // Make goto and label siblings
+
+    // goto and label are siblings
+    // eliminate goto
+    eliminateGoto(p, goto, label);
+    // remove it from the list of gotos
+    gotos.shift();
+  }
+
+  return p;
+}
+
 export function transformToConditional(goto) {
   return ([
     {
@@ -157,6 +189,10 @@ function findBlockClose(procedure, block) {
     }
   }
   return procedure[index];
+}
+
+function findMatchingLabel(listOfLabels, goto) {
+  return listOfLabels.filter(statement => (statement.command === "label" && statement.target === goto.target));
 }
 
 function isBlock(statement) {

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -43,14 +43,14 @@ export function eliminate(procedure) {
       p = transformOutward(p, goto);
     } else if (relationship === Relationship.DirectlyRelated) {
       // Make goto and label siblings
-      if (calculateLevel(goto) > calculateLevel(label)) {
+      if (calculateLevel(p, goto) > calculateLevel(p, label)) {
         p = transformOutward(p, goto);
       } else {
         if (p.indexOf(goto) > p.indexOf(label)) {
           p = lift(p, goto, label);
         }
         // Inward transformation
-        throw new Error("not implemented");
+        p = transformInward(p, goto, label);
       }
     } else {
       // goto and label are siblings
@@ -184,6 +184,7 @@ function transformInwardLoop(p, goto, block, label) {
 }
 
 function transformInwardConditional() {
+  throw new Error("not implemented");
 }
 
 export function lift(procedure, goto, label) {
@@ -285,7 +286,8 @@ function levelIncrement(statement, level = 0) {
 }
 
 function calculateLevel(procedure, statement) {
-  let level = 0;
+  // ignore the goto condition in terms of level
+  let level = statement.command === "goto" ? -1 : 0;
   for (let index = 0; index < procedure.length; index++) {
     level = levelIncrement(procedure[index], level);
     if (procedure[index] === statement) return level;
@@ -337,3 +339,17 @@ export const Relationship = {
   DirectlyRelated: "related",
   IndirectlyRelated: "unrelated"
 };
+
+export function prettyPrint(procedure) {
+  let level = 0;
+  return procedure.map(statement => {
+    if (isBlockEnd(statement)) {
+      level--;
+    }
+    let r = `${"  ".repeat(level)}${statement.command} ${statement.target || ""}`;
+    if (isBlock(statement)) {
+      level++;
+    }
+    return r;
+  }).join("\n");
+}

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -168,7 +168,7 @@ export function lift(procedure, goto, label) {
       command: "end"
     }
   );
-  const ifIndex = p.indexOf(goto) - 1;
+  const ifIndex = p.lastIndexOf(goto) - 1;
   p.splice(ifIndex, 3,
     {
       command: "store",

--- a/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/goto-elimination.js
@@ -30,3 +30,29 @@ export function transformToConditional(goto) {
     }
   ]);
 }
+
+export function eliminateLabel(procedure, label) {
+  return procedure.filter(p => p !== label);
+}
+
+export function eliminateGoto(procedure, goto, label) {
+  // only for siblings
+  const gotoIndex = procedure.indexOf(goto), labelIndex = procedure.indexOf(label);
+  if (gotoIndex < labelIndex) {
+    // eliminate using conditional
+    const ifIndex = gotoIndex - 1;
+    const p = [...procedure];
+    p[ifIndex] = Object.assign({...p[ifIndex]}, {target: `!${p[ifIndex].target}`});
+    p.splice(labelIndex, 0, { command: "end" });
+    p.splice(gotoIndex, 2);
+
+    return p;
+  } else {
+    // eliminate using do while
+  }
+}
+
+function isConditionalGoto(procedure, goto) {
+  const index = procedure.indexOf(goto);
+  return (procedure[index - 1].command === "if" && procedure[index + 1] === "end");
+}

--- a/packages/selenium-ide/src/neo/IO/legacy/migrate.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/migrate.js
@@ -19,6 +19,7 @@ import convert from "xml-js";
 import xmlescape from "xml-escape";
 import xmlunescape from "unescape";
 import JSZip from "jszip";
+import { eliminate } from "./goto-elimination";
 
 export function migrateProject(zippedData) {
   return JSZip.loadAsync(zippedData).then(zip => {
@@ -100,13 +101,13 @@ export function migrateTestCase(data) {
       {
         id: data,
         name: result.html.body.table.thead.tr.td._text,
-        commands: result.html.body.table.tbody.tr.filter(row => !/^wait/.test(row.td[0]._text)).map(row => (
+        commands: eliminate(result.html.body.table.tbody.tr.filter(row => !/^wait/.test(row.td[0]._text)).map(row => (
           {
             command: row.td[0]._text && row.td[0]._text.replace("AndWait", "") || "",
             target: xmlunescape(parseTarget(row.td[1])),
             value: xmlunescape(row.td[2]._text || "")
           }
-        ))
+        )))
       }
     ],
     suites: []

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -160,7 +160,7 @@ describe("goto elimination transformation", () => {
         command: "statement"
       }
     ];
-    expect(eliminateGoto(procedure)).toEqual([
+    expect(eliminateGoto(procedure, procedure[6], procedure[2])).toEqual([
       {
         command: "statement"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { transformToConditional, eliminate } from "../../../IO/legacy/goto-elimination";
+import { transformToConditional, eliminate, transformOutward } from "../../../IO/legacy/goto-elimination";
 
 describe("goto conditional conversion", () => {
   it("should convert unconditional goto to conditional goto", () => {
@@ -184,6 +184,208 @@ describe("goto elimination transformation", () => {
       {
         command: "endDo",
         target: "true"
+      },
+      {
+        command: "statement"
+      }
+    ]);
+  });
+});
+
+describe("outward movement transformation", () => {
+  it("should move goto out of a while", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "while",
+        target: "condition"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition2"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(transformOutward(procedure)).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "while",
+        target: "condition"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition2",
+        value: "label_1"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "break"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      }
+    ]);
+  });
+  it("should move goto out of an if", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition2"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(transformOutward(procedure)).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition2",
+        value: "label_1"
+      },
+      {
+        command: "if",
+        target: "!${label_1}"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
       },
       {
         command: "statement"

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -97,7 +97,7 @@ describe("goto elimination transformation", () => {
         command: "statement"
       }
     ];
-    expect(eliminateGoto(procedure)).toEqual([
+    expect(eliminateGoto(procedure, procedure[2], procedure[7])).toEqual([
       {
         command: "statement"
       },
@@ -193,27 +193,29 @@ describe("goto elimination transformation", () => {
 });
 
 describe("label elimination", () => {
-  const label = {
-    command: "label",
-    target: "label_1"
-  };
-  const procedure = [
-    {
-      command: "statement"
-    },
-    label,
-    {
-      command: "statement"
-    }
-  ];
-  expect(eliminateLabel(procedure, label)).toEqual([
-    {
-      command: "statement"
-    },
-    {
-      command: "statement"
-    }
-  ]);
+  it("should eliminate labels", () => {
+    const label = {
+      command: "label",
+      target: "label_1"
+    };
+    const procedure = [
+      {
+        command: "statement"
+      },
+      label,
+      {
+        command: "statement"
+      }
+    ];
+    expect(eliminateLabel(procedure, label)).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      }
+    ]);
+  });
 });
 
 describe("outward movement transformation", () => {

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -464,7 +464,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformInward(procedure)).toEqual([
+    expect(transformInward(procedure, procedure[2])).toEqual([
       {
         command: "statement"
       },
@@ -525,7 +525,235 @@ describe("inward movement transformation", () => {
     ]);
   });
   it("should move goto into an if's then", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition2"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "else"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(transformInward(procedure, procedure[2])).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition",
+        value: "label_1"
+      },
+      {
+        command: "if",
+        target: "!${label_1}"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "if",
+        target: "${label_1} || condition2"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "else"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ]);
   });
   it("should move goto into an if's else", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition2"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "else"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(transformInward(procedure, procedure[2])).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition",
+        value: "label_1"
+      },
+      {
+        command: "if",
+        target: "!${label_1}"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "if",
+        target: "!${label_1} && condition2"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "else"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ]);
   });
 });

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { transformToConditional, eliminate, transformOutward } from "../../../IO/legacy/goto-elimination";
+import { transformToConditional, eliminateGoto, eliminateLabel, transformOutward } from "../../../IO/legacy/goto-elimination";
 
 describe("goto conditional conversion", () => {
   it("should convert unconditional goto to conditional goto", () => {
@@ -97,7 +97,7 @@ describe("goto elimination transformation", () => {
         command: "statement"
       }
     ];
-    expect(eliminate(procedure)).toEqual([
+    expect(eliminateGoto(procedure)).toEqual([
       {
         command: "statement"
       },
@@ -160,7 +160,7 @@ describe("goto elimination transformation", () => {
         command: "statement"
       }
     ];
-    expect(eliminate(procedure)).toEqual([
+    expect(eliminateGoto(procedure)).toEqual([
       {
         command: "statement"
       },
@@ -190,6 +190,30 @@ describe("goto elimination transformation", () => {
       }
     ]);
   });
+});
+
+describe("label elimination", () => {
+  const label = {
+    command: "label",
+    target: "label_1"
+  };
+  const procedure = [
+    {
+      command: "statement"
+    },
+    label,
+    {
+      command: "statement"
+    }
+  ];
+  expect(eliminateLabel(procedure, label)).toEqual([
+    {
+      command: "statement"
+    },
+    {
+      command: "statement"
+    }
+  ]);
 });
 
 describe("outward movement transformation", () => {

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -473,7 +473,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformInward(procedure, procedure[2])).toEqual([
+    expect(transformInward(procedure, procedure[2], procedure[8])).toEqual([
       {
         command: "statement"
       },
@@ -585,7 +585,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformInward(procedure, procedure[2])).toEqual([
+    expect(transformInward(procedure, procedure[2], procedure[8])).toEqual([
       {
         command: "statement"
       },
@@ -701,7 +701,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformInward(procedure, procedure[2])).toEqual([
+    expect(transformInward(procedure, procedure[2], procedure[11])).toEqual([
       {
         command: "statement"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -18,7 +18,7 @@
 import {
   transformToConditional,
   eliminateGoto,
-  eliminateLabel,
+  eliminateLabels,
   transformOutward,
   transformInward,
   lift,
@@ -216,7 +216,7 @@ describe("label elimination", () => {
         command: "statement"
       }
     ];
-    expect(eliminateLabel(procedure, label)).toEqual([
+    expect(eliminateLabels(procedure)).toEqual([
       {
         command: "statement"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { transformToConditional } from "../../../IO/legacy/goto-elimination";
+import { transformToConditional, eliminate } from "../../../IO/legacy/goto-elimination";
 
 describe("goto conditional conversion", () => {
   it("should convert unconditional goto to conditional goto", () => {
@@ -65,5 +65,129 @@ describe("goto conditional conversion", () => {
 
 describe("goto elimination transformation", () => {
   it("should eliminate goto before label statement", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "true"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(eliminate(procedure)).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "!true"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      }
+    ]);
+  });
+  it("should eliminate goto after label statement", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "true"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(eliminate(procedure)).toEqual([
+      {
+        command: "statement"
+      },
+
+      {
+        command: "statement"
+      },
+      {
+        command: "do"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "endDo",
+        target: "true"
+      },
+      {
+        command: "statement"
+      }
+    ]);
   });
 });

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -419,3 +419,10 @@ describe("outward movement transformation", () => {
     ]);
   });
 });
+
+describe("inward movement transformation", () => {
+  it("should move goto into a while", () => {
+  });
+  it("should move goto into an if", () => {
+  });
+});

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -363,7 +363,7 @@ describe("outward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformOutward(procedure)).toEqual([
+    expect(transformOutward(procedure, procedure[4])).toEqual([
       {
         command: "statement"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { transformToConditional, eliminateGoto, eliminateLabel, transformOutward } from "../../../IO/legacy/goto-elimination";
+import { transformToConditional, eliminateGoto, eliminateLabel, transformOutward, transformInward } from "../../../IO/legacy/goto-elimination";
 
 describe("goto conditional conversion", () => {
   it("should convert unconditional goto to conditional goto", () => {
@@ -422,7 +422,110 @@ describe("outward movement transformation", () => {
 
 describe("inward movement transformation", () => {
   it("should move goto into a while", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "while",
+        target: "condition2"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(transformInward(procedure)).toEqual([
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition",
+        value: "label_1"
+      },
+      {
+        command: "if",
+        target: "!${label_1}"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "while",
+        target: "${label_1} || condition2"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "storeValue",
+        target: "false",
+        value: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ]);
   });
-  it("should move goto into an if", () => {
+  it("should move goto into an if's then", () => {
+  });
+  it("should move goto into an if's else", () => {
   });
 });

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -1,0 +1,69 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { transformToConditional } from "../../../IO/legacy/goto-elimination";
+
+describe("goto conditional conversion", () => {
+  it("should convert unconditional goto to conditional goto", () => {
+    const procedure = [
+      {
+        command: "goto",
+        target: "label_1"
+      }
+    ];
+    expect(transformToConditional(procedure[0])).toEqual([
+      {
+        command: "if",
+        target: "true"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      }
+    ]);
+  });
+  it("should convert compound goto to conditional goto", () => {
+    const procedure = [
+      {
+        command: "gotoIf",
+        target: "condition",
+        value: "label_1"
+      }
+    ];
+    expect(transformToConditional(procedure[0])).toEqual([
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      }
+    ]);
+  });
+});
+
+describe("goto elimination transformation", () => {
+  it("should eliminate goto before label statement", () => {
+  });
+});

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { transformToConditional, eliminateGoto, eliminateLabel, transformOutward, transformInward } from "../../../IO/legacy/goto-elimination";
+import { transformToConditional, eliminateGoto, eliminateLabel, transformOutward, transformInward, lift } from "../../../IO/legacy/goto-elimination";
 
 describe("goto conditional conversion", () => {
   it("should convert unconditional goto to conditional goto", () => {
@@ -750,6 +750,80 @@ describe("inward movement transformation", () => {
       },
       {
         command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ]);
+  });
+});
+
+describe("lifting transformation", () => {
+  it("should lift the goto above it's label", () => {
+    const procedure = [
+      {
+        command: "statement"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "if",
+        target: "condition"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "statement"
+      }
+    ];
+    expect(lift(procedure, procedure[4], procedure[1])).toEqual([
+      {
+        command: "storeValue",
+        target: "false",
+        value: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "do"
+      },
+      {
+        command: "if",
+        target: "${label_1}"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "storeValue",
+        target: "condition",
+        value: "label_1"
+      },
+      {
+        command: "endDo",
+        target: "${label_1}"
       },
       {
         command: "statement"

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -649,7 +649,7 @@ describe("inward movement transformation", () => {
       }
     ]);
   });
-  it("should move goto into an if's else", () => {
+  it.skip("should move goto into an if's else", () => {
     const procedure = [
       {
         command: "statement"

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -283,7 +283,7 @@ describe("outward movement transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition2",
         value: "label_1"
       },
@@ -384,7 +384,7 @@ describe("outward movement transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition2",
         value: "label_1"
       },
@@ -478,7 +478,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition",
         value: "label_1"
       },
@@ -518,7 +518,7 @@ describe("inward movement transformation", () => {
         target: "label_1"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "false",
         value: "label_1"
       },
@@ -590,7 +590,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition",
         value: "label_1"
       },
@@ -706,7 +706,7 @@ describe("inward movement transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition",
         value: "label_1"
       },
@@ -797,7 +797,7 @@ describe("lifting transformation", () => {
     ];
     expect(lift(procedure, procedure[4], procedure[1])).toEqual([
       {
-        command: "storeValue",
+        command: "store",
         target: "false",
         value: "label_1"
       },
@@ -826,7 +826,7 @@ describe("lifting transformation", () => {
         command: "statement"
       },
       {
-        command: "storeValue",
+        command: "store",
         target: "condition",
         value: "label_1"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -262,7 +262,7 @@ describe("outward movement transformation", () => {
         command: "statement"
       }
     ];
-    expect(transformOutward(procedure)).toEqual([
+    expect(transformOutward(procedure, procedure[4])).toEqual([
       {
         command: "statement"
       },

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/goto-elimination.spec.js
@@ -848,8 +848,15 @@ describe("goto-label relations", () => {
         command: "statement"
       },
       {
+        command: "if",
+        target: "true"
+      },
+      {
         command: "goto",
         target: "label_1"
+      },
+      {
+        command: "end"
       },
       {
         command: "statement"
@@ -862,12 +869,16 @@ describe("goto-label relations", () => {
         command: "statement"
       }
     ];
-    expect(relation(procedure, procedure[1], procedure[3])).toBe(Relationship.Siblings);
+    expect(relation(procedure, procedure[2], procedure[5])).toBe(Relationship.Siblings);
   });
   it("goto should be sibling of label inside the same block", () => {
     const procedure = [
       {
         command: "statement"
+      },
+      {
+        command: "while",
+        target: "true"
       },
       {
         command: "if",
@@ -876,6 +887,9 @@ describe("goto-label relations", () => {
       {
         command: "goto",
         target: "label_1"
+      },
+      {
+        command: "end"
       },
       {
         command: "statement"
@@ -891,7 +905,7 @@ describe("goto-label relations", () => {
         command: "end"
       }
     ];
-    expect(relation(procedure, procedure[2], procedure[4])).toBe(Relationship.Siblings);
+    expect(relation(procedure, procedure[3], procedure[6])).toBe(Relationship.Siblings);
   });
   it("should work for reverse label-goto as well", () => {
     const procedure = [
@@ -900,13 +914,20 @@ describe("goto-label relations", () => {
         target: "label_1"
       },
       {
+        command: "if",
+        target: "true"
+      },
+      {
         command: "goto",
         target: "label_1"
+      },
+      {
+        command: "end"
       }
     ];
-    expect(relation(procedure, procedure[1], procedure[0])).toBe(Relationship.Siblings);
+    expect(relation(procedure, procedure[2], procedure[0])).toBe(Relationship.Siblings);
   });
-  it("should be directly related if the goto is nested inside the label block", () => {
+  it("goto should be sibling of label even with block between them", () => {
     const procedure = [
       {
         command: "if",
@@ -920,11 +941,47 @@ describe("goto-label relations", () => {
         command: "end"
       },
       {
+        command: "while"
+      },
+      {
+        command: "statement"
+      },
+      {
+        command: "end"
+      },
+      {
         command: "label",
         target: "label_1"
       }
     ];
-    expect(relation(procedure, procedure[1], procedure[3])).toBe(Relationship.DirectlyRelated);
+    expect(relation(procedure, procedure[1], procedure[5])).toBe(Relationship.Siblings);
+  });
+  it("should be directly related if the goto is nested inside the label block", () => {
+    const procedure = [
+      {
+        command: "while",
+        target: "true"
+      },
+      {
+        command: "if",
+        target: "true"
+      },
+      {
+        command: "goto",
+        target: "label_1"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "end"
+      },
+      {
+        command: "label",
+        target: "label_1"
+      }
+    ];
+    expect(relation(procedure, procedure[2], procedure[5])).toBe(Relationship.DirectlyRelated);
   });
   it("should be directly related if the label is nested inside the goto block", () => {
     const procedure = [
@@ -940,11 +997,18 @@ describe("goto-label relations", () => {
         command: "end"
       },
       {
+        command: "if",
+        target: "true"
+      },
+      {
         command: "goto",
         target: "label_1"
+      },
+      {
+        command: "end"
       }
     ];
-    expect(relation(procedure, procedure[3], procedure[1])).toBe(Relationship.DirectlyRelated);
+    expect(relation(procedure, procedure[4], procedure[1])).toBe(Relationship.DirectlyRelated);
   });
   it("should be indirectly related if goto and label are nested inside different branches of the procedure", () => {
     const procedure = [
@@ -964,6 +1028,10 @@ describe("goto-label relations", () => {
         target: "true"
       },
       {
+        command: "while",
+        target: "true"
+      },
+      {
         command: "if",
         target: "true"
       },
@@ -973,8 +1041,11 @@ describe("goto-label relations", () => {
       },
       {
         command: "end"
+      },
+      {
+        command: "end"
       }
     ];
-    expect(relation(procedure, procedure[5], procedure[1])).toBe(Relationship.IndirectlyRelated);
+    expect(relation(procedure, procedure[6], procedure[1])).toBe(Relationship.IndirectlyRelated);
   });
 });

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
@@ -57,7 +57,7 @@ describe("selenium test case migration", () => {
   it("should decode the input post conversion", () => {
     const file = fs.readFileSync(path.join(__dirname, "IDE_test_8.html")).toString();
     const project = migrateTestCase(file);
-    expect(project.tests[0].commands[16].target).toBe("//a[@onclick='return confirm(\"Wollen Sie den Datensatz wirklich löschen?\")']");
+    expect(project.tests[0].commands[13].target).toBe("//a[@onclick='return confirm(\"Wollen Sie den Datensatz wirklich löschen?\")']");
   });
 });
 

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
@@ -57,7 +57,7 @@ describe("selenium test case migration", () => {
   it("should decode the input post conversion", () => {
     const file = fs.readFileSync(path.join(__dirname, "IDE_test_8.html")).toString();
     const project = migrateTestCase(file);
-    expect(project.tests[0].commands[14].target).toBe("//a[@onclick='return confirm(\"Wollen Sie den Datensatz wirklich löschen?\")']");
+    expect(project.tests[0].commands[16].target).toBe("//a[@onclick='return confirm(\"Wollen Sie den Datensatz wirklich löschen?\")']");
   });
 });
 

--- a/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
@@ -41,6 +41,17 @@ describe("Command", () => {
     command.setCommand("test invalid");
     expect(command.isValid).toBeFalsy();
   });
+  it("should replace undefined input with empty strings", () => {
+    const command = new Command();
+    command.setCommand();
+    command.setTarget();
+    command.setValue();
+    command.setComment();
+    expect(command.command).toEqual("");
+    expect(command.target).toEqual("");
+    expect(command.value).toEqual("");
+    expect(command.comment).toEqual("");
+  });
   it("should set the target", () => {
     const command = new Command();
     command.setTarget("a");

--- a/packages/selenium-ide/src/neo/models/Command.js
+++ b/packages/selenium-ide/src/neo/models/Command.js
@@ -43,23 +43,23 @@ export default class Command {
   }
 
   @action.bound setComment(comment) {
-    this.comment = comment;
+    this.comment = comment || "";
   }
 
   @action.bound setCommand(command) {
     if (CommandsValues[command]) {
       this.command = CommandsValues[command];
     } else {
-      this.command = command;
+      this.command = command || "";
     }
   }
 
   @action.bound setTarget(target) {
-    this.target = target;
+    this.target = target || "";
   }
 
   @action.bound setValue(value) {
-    this.value = value.replace(/\n/g, "\\n");
+    this.value = value ? value.replace(/\n/g, "\\n") : "";
   }
 
   static fromJS = function(jsRep) {


### PR DESCRIPTION
The plan is to not support the likes of `goto` in the IDE, rather introduce better alternatives like `if` and `while`, in order to do that we adding conversion of the old flow to the new one.  
<br />
Convert unstructured control flow (e.g. `goto` `gotoIf`) to structured one.  
Before merging will require the IDE to support  
 - `if`
 - `while`
 - `do`
 - `break`