### PR TITLE
Adding a drag drop feature on TestTable.

### DIFF
--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -51,7 +51,7 @@ export default class TestTable extends React.Component {
     removeCommand: PropTypes.func,
     swapCommands: PropTypes.func,
     clearAllCommands: PropTypes.func,
-    accepts: PropTypes.arrayOf(PropTypes.string),
+    accepts: PropTypes.any,
   };
   render() {
     return ([

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -26,16 +26,20 @@ import TestRow from "../TestRow";
 import { DropTarget } from 'react-dnd'
 import "./style.css";
 
-const boxTarget = {
+const fileTarget = {
   drop(props, monitor) {
     if (props.onDrop) {
-      props.onDrop(props, monitor)
+      let fileName = monitor.getItem().files[0].name;
+      if((/\.side$|\.html$/).test(fileName)){
+        props.onDrop(props, monitor)
+      }
     }
   }
 }
 
-@DropTarget(props => props.accepts, boxTarget, (connect, monitor) => ({
-  connectDropTarget: connect.dropTarget()
+@DropTarget(props => props.accepts, fileTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver()
 }))
 
 @observer
@@ -67,7 +71,7 @@ export default class TestTable extends React.Component {
         </table>
       </div>,
       this.props.connectDropTarget(
-        <div key="body" className="test-table test-table-body">
+        <div key="body" className="test-table test-table-body" style={{ border: this.props.isOver? "2px #40A6FF solid" : "transparent"}}>
           <table>
             <tbody>
               { this.props.commands ? this.props.commands.map((command, index) => (

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -20,11 +20,11 @@ import PropTypes from "prop-types";
 import { observer } from "mobx-react";
 import { PropTypes as MobxPropTypes } from "mobx-react";
 import classNames from "classnames";
+import { DropTarget } from "react-dnd";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
 import ModalState from "../../stores/view/ModalState";
 import TestRow from "../TestRow";
-import { DropTarget } from 'react-dnd'
 import "./style.css";
 
 const fileTarget = {
@@ -32,7 +32,7 @@ const fileTarget = {
     if (props.onDrop) {
       let fileName = monitor.getItem().files[0].name;
       if((/\.side$|\.html$/).test(fileName)){
-        props.onDrop(props, monitor)
+        props.onDrop(props, monitor);
       }else{
         ModalState.showAlert({
           title: `'${fileName}' can't be loaded.`,
@@ -42,7 +42,7 @@ const fileTarget = {
       }
     }
   }
-}
+};
 
 @DropTarget(props => props.accepts, fileTarget, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
@@ -63,6 +63,8 @@ export default class TestTable extends React.Component {
     swapCommands: PropTypes.func,
     clearAllCommands: PropTypes.func,
     accepts: PropTypes.any,
+    connectDropTarget: PropTypes.func,
+    isOver: PropTypes.bool
   };
   render() {
     return ([

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -22,6 +22,7 @@ import { PropTypes as MobxPropTypes } from "mobx-react";
 import classNames from "classnames";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
+import ModalState from "../../stores/view/ModalState";
 import TestRow from "../TestRow";
 import { DropTarget } from 'react-dnd'
 import "./style.css";
@@ -32,6 +33,12 @@ const fileTarget = {
       let fileName = monitor.getItem().files[0].name;
       if((/\.side$|\.html$/).test(fileName)){
         props.onDrop(props, monitor)
+      }else{
+        ModalState.showAlert({
+          title: `'${fileName}' can't be loaded.`,
+          description: "This format is not supported.",
+          confirmLabel: "Close"
+        });
       }
     }
   }

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -23,7 +23,20 @@ import classNames from "classnames";
 import UiState from "../../stores/view/UiState";
 import PlaybackState from "../../stores/view/PlaybackState";
 import TestRow from "../TestRow";
+import { DropTarget } from 'react-dnd'
 import "./style.css";
+
+const boxTarget = {
+  drop(props, monitor) {
+    if (props.onDrop) {
+      props.onDrop(props, monitor)
+    }
+  }
+}
+
+@DropTarget(props => props.accepts, boxTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget()
+}))
 
 @observer
 export default class TestTable extends React.Component {
@@ -37,7 +50,8 @@ export default class TestTable extends React.Component {
     addCommand: PropTypes.func,
     removeCommand: PropTypes.func,
     swapCommands: PropTypes.func,
-    clearAllCommands: PropTypes.func
+    clearAllCommands: PropTypes.func,
+    accepts: PropTypes.arrayOf(PropTypes.string),
   };
   render() {
     return ([
@@ -52,55 +66,57 @@ export default class TestTable extends React.Component {
           </thead>
         </table>
       </div>,
-      <div key="body" className="test-table test-table-body">
-        <table>
-          <tbody>
-            { this.props.commands ? this.props.commands.map((command, index) => (
-              <TestRow
-                key={command.id}
-                id={command.id}
-                className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}
-                selected={this.props.selectedCommand === command.id}
-                index={index}
-                comment={command.comment}
-                command={command.command}
-                target={command.target}
-                value={command.value}
-                isBreakpoint={command.isBreakpoint}
-                toggleBreakpoint={command.toggleBreakpoint}
-                dragInProgress={UiState.dragInProgress}
-                onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
-                startPlayingHere={() => { PlaybackState.startPlaying(command); }}
-                executeCommand={() => { PlaybackState.playCommand(command); }}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
-                moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
-                insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
-                remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
-                swapCommands={this.props.swapCommands}
-                setDrag={UiState.setDrag}
-                clipboard={UiState.clipboard}
-                copyToClipboard={() => { UiState.copyToClipboard(command); }}
-                clearAllCommands={this.props.clearAllCommands}
-                setSectionFocus={UiState.setSectionFocus}
-              />
-            )).concat(
-              <TestRow
-                id={UiState.pristineCommand.id}
-                key={UiState.selectedTest.test.id}
-                selected={this.props.selectedCommand === UiState.pristineCommand.id}
-                command={UiState.pristineCommand.command}
-                target={UiState.pristineCommand.target}
-                value={UiState.pristineCommand.value}
-                onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
-                addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
-                moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
-                clipboard={UiState.clipboard}
-                setSectionFocus={UiState.setSectionFocus}
-              />) : null }
-          </tbody>
-        </table>
-      </div>
+      this.props.connectDropTarget(
+        <div key="body" className="test-table test-table-body">
+          <table>
+            <tbody>
+              { this.props.commands ? this.props.commands.map((command, index) => (
+                <TestRow
+                  key={command.id}
+                  id={command.id}
+                  className={classNames(PlaybackState.commandState.get(command.id) ? PlaybackState.commandState.get(command.id).state : "")}
+                  selected={this.props.selectedCommand === command.id}
+                  index={index}
+                  comment={command.comment}
+                  command={command.command}
+                  target={command.target}
+                  value={command.value}
+                  isBreakpoint={command.isBreakpoint}
+                  toggleBreakpoint={command.toggleBreakpoint}
+                  dragInProgress={UiState.dragInProgress}
+                  onClick={this.props.selectCommand ? () => { this.props.selectCommand(command); } : null}
+                  startPlayingHere={() => { PlaybackState.startPlaying(command); }}
+                  executeCommand={() => { PlaybackState.playCommand(command); }}
+                  moveSelectionUp={() => { UiState.selectCommandByIndex(index - 1); }}
+                  moveSelectionDown={() => { UiState.selectCommandByIndex(index + 1); }}
+                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(index, command); } : null}
+                  insertCommand={this.props.addCommand ? (command) => { this.props.selectCommand(this.props.addCommand(index, command)); } : null}
+                  remove={this.props.removeCommand ? () => { this.props.removeCommand(index, command); } : null}
+                  swapCommands={this.props.swapCommands}
+                  setDrag={UiState.setDrag}
+                  clipboard={UiState.clipboard}
+                  copyToClipboard={() => { UiState.copyToClipboard(command); }}
+                  clearAllCommands={this.props.clearAllCommands}
+                  setSectionFocus={UiState.setSectionFocus}
+                />
+              )).concat(
+                <TestRow
+                  id={UiState.pristineCommand.id}
+                  key={UiState.selectedTest.test.id}
+                  selected={this.props.selectedCommand === UiState.pristineCommand.id}
+                  command={UiState.pristineCommand.command}
+                  target={UiState.pristineCommand.target}
+                  value={UiState.pristineCommand.value}
+                  onClick={() => (this.props.selectCommand(UiState.pristineCommand))}
+                  addCommand={this.props.addCommand ? (command) => { this.props.addCommand(this.props.commands.length, command); } : null}
+                  moveSelectionUp={() => { UiState.selectCommandByIndex(this.props.commands.length - 1); }}
+                  clipboard={UiState.clipboard}
+                  setSectionFocus={UiState.setSectionFocus}
+                />) : null }
+            </tbody>
+          </table>
+        </div>
+      )
     ]);
   }
 }

--- a/packages/selenium-ide/src/neo/containers/Editor/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Editor/index.jsx
@@ -19,8 +19,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { observer } from "mobx-react";
 import { modifier } from "modifier-keys";
-import { DragDropContextProvider } from 'react-dnd'
-import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
+import { DragDropContextProvider } from "react-dnd";
+import HTML5Backend, { NativeTypes } from "react-dnd-html5-backend";
 import UiState from "../../stores/view/UiState";
 import ToolBar from "../../components/ToolBar";
 import UrlBar from "../../components/UrlBar";
@@ -33,14 +33,14 @@ import "./style.css";
     super(props);
     this.addCommand = this.addCommand.bind(this);
     this.removeCommand = this.removeCommand.bind(this);
-    this.handleFileDrop = this.handleFileDrop.bind(this)
+    this.handleFileDrop = this.handleFileDrop.bind(this);
   }
   static propTypes = {
     test: PropTypes.object,
     url: PropTypes.string.isRequired,
     urls: PropTypes.array,
     setUrl: PropTypes.func.isRequired,
-    load: PropTypes.func,
+    load: PropTypes.func
   };
   addCommand(index, command) {
     if (command) {

--- a/packages/selenium-ide/src/neo/containers/Editor/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Editor/index.jsx
@@ -19,7 +19,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { observer } from "mobx-react";
 import { modifier } from "modifier-keys";
-import { DragDropContext, DragDropContextProvider } from 'react-dnd'
+import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
 import UiState from "../../stores/view/UiState";
 import ToolBar from "../../components/ToolBar";
@@ -28,7 +28,6 @@ import TestTable from "../../components/TestTable";
 import CommandForm from "../../components/CommandForm";
 import "./style.css";
 
-@DragDropContext(HTML5Backend)
 @observer export default class Editor extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/selenium-ide/src/neo/containers/Editor/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Editor/index.jsx
@@ -19,6 +19,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { observer } from "mobx-react";
 import { modifier } from "modifier-keys";
+import { DragDropContext, DragDropContextProvider } from 'react-dnd'
+import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
 import UiState from "../../stores/view/UiState";
 import ToolBar from "../../components/ToolBar";
 import UrlBar from "../../components/UrlBar";
@@ -26,17 +28,20 @@ import TestTable from "../../components/TestTable";
 import CommandForm from "../../components/CommandForm";
 import "./style.css";
 
+@DragDropContext(HTML5Backend)
 @observer export default class Editor extends React.Component {
   constructor(props) {
     super(props);
     this.addCommand = this.addCommand.bind(this);
     this.removeCommand = this.removeCommand.bind(this);
+    this.handleFileDrop = this.handleFileDrop.bind(this)
   }
   static propTypes = {
     test: PropTypes.object,
     url: PropTypes.string.isRequired,
     urls: PropTypes.array,
-    setUrl: PropTypes.func.isRequired
+    setUrl: PropTypes.func.isRequired,
+    load: PropTypes.func,
   };
   addCommand(index, command) {
     if (command) {
@@ -75,27 +80,36 @@ import "./style.css";
   handleContextMenu(e){
     e.preventDefault();
   }
+  handleFileDrop(item, monitor) {
+    if (monitor) {
+      this.props.load(monitor.getItem().files[0]);
+    }
+  }
   render() {
     return (
-      <main className="editor" onKeyDown={this.handleKeyDown.bind(this)} onContextMenu={this.handleContextMenu.bind(this)}>
-        <ToolBar />
-        <UrlBar url={this.props.url} urls={this.props.urls} setUrl={this.props.setUrl} />
-        <TestTable
-          commands={this.props.test ? this.props.test.commands : null}
-          selectedCommand={UiState.selectedCommand ? UiState.selectedCommand.id : null}
-          selectCommand={UiState.selectCommand}
-          addCommand={this.addCommand}
-          removeCommand={this.removeCommand}
-          clearAllCommands={this.props.test ? this.props.test.clearAllCommands : null}
-          swapCommands={this.props.test ? this.props.test.swapCommands : null}
-        />
-        <CommandForm
-          command={UiState.selectedCommand}
-          setCommand={this.handleCommandChange}
-          isSelecting={UiState.isSelectingTarget}
-          onSubmit={UiState.selectNextCommand}
-        />
-      </main>
+      <DragDropContextProvider backend={HTML5Backend}>
+        <main className="editor" onKeyDown={this.handleKeyDown.bind(this)} onContextMenu={this.handleContextMenu.bind(this)}>
+          <ToolBar />
+          <UrlBar url={this.props.url} urls={this.props.urls} setUrl={this.props.setUrl} />
+          <TestTable
+            commands={this.props.test ? this.props.test.commands : null}
+            selectedCommand={UiState.selectedCommand ? UiState.selectedCommand.id : null}
+            selectCommand={UiState.selectCommand}
+            addCommand={this.addCommand}
+            removeCommand={this.removeCommand}
+            clearAllCommands={this.props.test ? this.props.test.clearAllCommands : null}
+            swapCommands={this.props.test ? this.props.test.swapCommands : null}
+            onDrop={this.handleFileDrop}
+            accepts={NativeTypes["FILE"]}
+          />
+          <CommandForm
+            command={UiState.selectedCommand}
+            setCommand={this.handleCommandChange}
+            isSelecting={UiState.isSelectingTarget}
+            onSubmit={UiState.selectNextCommand}
+          />
+        </main>
+      </DragDropContextProvider>
     );
   }
 }

--- a/packages/selenium-ide/src/neo/containers/Panel/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Panel/index.jsx
@@ -167,6 +167,7 @@ modify(project);
                   urls={this.state.project.urls}
                   setUrl={this.state.project.setUrl}
                   test={UiState.selectedTest.test}
+                  load={loadProject.bind(undefined, project)}
                 />
               </SplitPane>
             </div>


### PR DESCRIPTION
There was something unfortunate about it.

- I could not get information of file until dropping. So I couldn't use `canDrop` attribute.
![filedndwarning](https://user-images.githubusercontent.com/33743343/38542735-a1d85d38-3cdd-11e8-880e-3f3fcbd57b91.PNG)
- [react-dropzone](https://github.com/react-dropzone/react-dropzone/) is possible to classify using mime-type. But this can't get and distinguish mime-type of `.side`. So I failed.

I didn't have a choice but to add a warning message after dropping the file.
This is [video](https://drive.google.com/file/d/1Mw711G6WrLxCFwBSnfIiIDZQnD-s-5lm/view).
