### PR TITLE
if attribute 'comment' does not exist, fill comment value by empty

### DIFF
--- a/packages/selenium-ide/src/neo/models/Command.js
+++ b/packages/selenium-ide/src/neo/models/Command.js
@@ -80,7 +80,7 @@ export default class Command {
 
   static fromJS = function(jsRep) {
     const command = new Command(jsRep.id);
-    command.setComment(jsRep.comment);
+    command.setComment(jsRep.comment ? jsRep.comment : "");
     command.setCommand(jsRep.command);
     command.setTarget(jsRep.target);
     command.setValue(jsRep.value);


### PR DESCRIPTION
If you used old `.side`, there is no `comment` of `Command`,
So comment was still left even if I load the new project.
This is not necessary, but I think it would be nice.