### PR TITLE
Recorder - migrating DOMNodeInserted to MutationObserver

### DIFF
--- a/packages/selenium-ide/src/content/record-api.js
+++ b/packages/selenium-ide/src/content/record-api.js
@@ -27,6 +27,7 @@ function Recorder(window) {
 }
 
 Recorder.eventHandlers = {};
+Recorder.mutationObservers = {};
 Recorder.addEventHandler = function(handlerName, eventName, handler, options) {
   handler.handlerName = handlerName;
   if (!options) options = false;
@@ -35,6 +36,13 @@ Recorder.addEventHandler = function(handlerName, eventName, handler, options) {
     this.eventHandlers[key] = [];
   }
   this.eventHandlers[key].push(handler);
+};
+
+Recorder.addMutationObserver = function(observerName, callback, config) {
+  const observer = new MutationObserver(callback);
+  observer.observerName = observerName;
+  observer.config = config;
+  this.mutationObservers[observerName] = observer;
 };
 
 Recorder.prototype.parseEventKey = function(eventKey) {
@@ -59,6 +67,11 @@ Recorder.prototype.attach = function() {
       this.eventListeners[eventKey].push(handlers[i]);
     }
   }
+
+  for (let observerName in Recorder.mutationObservers) {
+    const observer = Recorder.mutationObservers[observerName];
+    observer.observe(this.window.document.body, observer.config);
+  }
 };
 
 Recorder.prototype.detach = function() {
@@ -71,6 +84,11 @@ Recorder.prototype.detach = function() {
     }
   }
   delete this.eventListeners;
+
+  for (let observerName in Recorder.mutationObservers) {
+    const observer = Recorder.mutationObservers[observerName];
+    observer.disconnect();
+  }
 };
 
 // show element

--- a/packages/selenium-ide/src/content/record.js
+++ b/packages/selenium-ide/src/content/record.js
@@ -432,8 +432,20 @@ if (Recorder) {
 
   // InfluentialMouseoverExt & InfluentialScrollingExt, Shuo-Heng Shih, SELAB, CSIE, NCKU, 2016/11/08
   // Record: mouseOver
-  Recorder.addEventHandler("mouseOver", "DOMNodeInserted", function() {
+  Recorder.addMutationObserver("DOMNodeInserted", function(mutations) {
     if (pageLoaded === true && window.document.documentElement.getElementsByTagName("*").length > nowNode) {
+      // Get list of inserted nodes from the mutations list to simulate 'DOMNodeInserted'.
+      const insertedNodes = mutations.reduce((nodes, mutation) => {
+        if (mutation.type === "childList") {
+          nodes.push.apply(nodes, mutation.addedNodes);
+        }
+        return nodes;
+      }, []);
+      // If no nodes inserted, just bail.
+      if (!insertedNodes.length) {
+        return;
+      }
+
       let self = this;
       if (this.scrollDetector) {
         //TODO: fix target
@@ -454,7 +466,7 @@ if (Recorder) {
         delete this.mouseoverLocator;
       }
     }
-  }, true);
+  }, {childList:true, subtree:true});
 
   // InfluentialMouseoverExt & InfluentialScrollingExt, Shuo-Heng Shih, SELAB, CSIE, NCKU, 2016/08/02
   let readyTimeOut = null;


### PR DESCRIPTION
# Summary:
The onDOMNodeInserted event is deprecated, and throws a warning.
Replacing usage of onDOMNodeInserted event in the 'Record' module
with a MutationObserver.

#### Notes:
There are more instances of mutation events in selenium-api.  If possible,
it would be nice to move those to mutation observers as well.