### PR TITLE
fixed error message when someone drags testrow to outside

### DIFF
--- a/packages/selenium-ide/src/neo/components/SuiteDropzone/index.jsx
+++ b/packages/selenium-ide/src/neo/components/SuiteDropzone/index.jsx
@@ -12,7 +12,7 @@ export default class SuiteDropzone extends React.Component {
   }
   render() {
     return (
-      <Dropzone className="suite-dropzone" acceptClassName="accept" accept=".side" disableClick={true} multiple={false} onDropAccepted={this.onDrop.bind(this)}>
+      <Dropzone className="suite-dropzone" disablePreview={true} acceptClassName="accept" accept=".side" disableClick={true} multiple={false} onDropAccepted={this.onDrop.bind(this)}>
         {this.props.children}
       </Dropzone>
     );


### PR DESCRIPTION
How to reproduce.
 - Just drag second testrow to last.

![image](https://user-images.githubusercontent.com/33743343/39231617-9fb5e36c-48a5-11e8-873f-da23cbb36b5f.png)


This is a bug of `dropzone`.
I didn't create issue about this problem.
This is workaround.
I got this message from selenium-ide.

![image](https://user-images.githubusercontent.com/33743343/39231185-336b6430-48a4-11e8-99fb-544913443044.png)

So I searched for the cause in `dropzone`.
I can find this [code](https://github.com/react-dropzone/react-dropzone/search?utf8=%E2%9C%93&q=createObjectURL&type=).
