### PR TITLE
fixed #195

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
@@ -335,6 +335,7 @@ export default class ExtCommand {
       // we assume that there has an "open" command
       // select Frame directly will cause failed
       this.playingTabStatus[this.currentPlayingTabId] = true;
+      this.doOpen(tab.url);
     }
   }
 


### PR DESCRIPTION
I found some case of #195.
This is not general case. But If we add this, it will be better.

1. not install `selenium-ide`, and open and site on the tab.
2. after installing selenium, don't refresh the tab opened.
3. open selenium-ide and start the script which the first command is not `open` for example `store`

This case didn't run the script.
This case was occurred me while I installed and uninstalled the selenium-ide.
