### PR TITLE
WIP: Standardizing store commands behavior

### DIFF
--- a/packages/selenium-ide/src/content/selenium-api.js
+++ b/packages/selenium-ide/src/content/selenium-api.js
@@ -562,6 +562,10 @@ Selenium.prototype.doStore = function(value, varName) {
   browser.runtime.sendMessage({ "storeStr": value, "storeVar": varName });
 };
 
+Selenium.prototype.doStoreEval = function() {
+  throw new Error("store eval is obsolete please migrate to execute script");
+};
+
 Selenium.prototype.doStoreText = function(locator, varName) {
   let element = this.browserbot.findElement(locator);
   browser.runtime.sendMessage({ "storeStr": element.textContent, "storeVar": varName });
@@ -2934,7 +2938,7 @@ Selenium.prototype.doWaitForPageToLoad.dontCheckAlertsAndConfirms = true;
 Selenium.prototype.preprocessParameter = function(value) {
   let match = value.match(/^javascript\{((.|\r?\n)+)\}$/);
   if (match && match[1]) {
-    let result = eval(match[1]);
+    let result = window.eval(match[1]);
     return result == null ? null : result.toString();
   }
   return this.replaceVariables(value);
@@ -3139,6 +3143,10 @@ Selenium.prototype.doDeleteAllVisibleCookies = function() {
     }
     //LOG.setLogLevelThreshold(logLevel);
 }*/
+
+Selenium.prototype.doExecuteScript = function(script, varName) {
+  browser.runtime.sendMessage({ "storeStr": window.eval(script), "storeVar": varName });
+};
 
 Selenium.prototype.doRunScript = function(script) {
   /**

--- a/packages/selenium-ide/src/neo/models/Command.js
+++ b/packages/selenium-ide/src/neo/models/Command.js
@@ -204,6 +204,9 @@ class CommandList {
     [ "echo", {
       name: "echo"
     }],
+    [ "executeScript", {
+      name: "execute script"
+    }],
     [ "editContent", {
       name: "edit content",
       type: TargetTypes.LOCATOR

--- a/packages/selianize/__tests__/command.spec.js
+++ b/packages/selianize/__tests__/command.spec.js
@@ -139,6 +139,14 @@ describe("command code emitter", () => {
     };
     return expect(CommandEmitter.emit(command)).resolves.toBe(`driver.executeScript(\`${command.target}\`);`);
   });
+  it("should emit `execute script` command", () => {
+    const command = {
+      command: "executeScript",
+      target: "javascript",
+      value: "myVar"
+    };
+    return expect(CommandEmitter.emit(command)).resolves.toBe(`var ${command.value} = await driver.executeScript("${command.target}");`);
+  });
   it("should emit `pause` command", () => {
     const command = {
       command: "pause",

--- a/packages/selianize/src/command.js
+++ b/packages/selianize/src/command.js
@@ -31,6 +31,7 @@ const emitters = {
   sendKeys: emitSendKeys,
   echo: emitEcho,
   runScript: emitRunScript,
+  executeScript: emitExecuteScript,
   pause: emitPause,
   verifyChecked: emitVerifyChecked,
   verifyNotChecked: emitVerifyNotChecked,
@@ -164,6 +165,10 @@ async function emitUncheck(locator) {
 
 async function emitRunScript(script) {
   return Promise.resolve(`driver.executeScript(\`${script}\`);`);
+}
+
+async function emitExecuteScript(script, varName) {
+  return Promise.resolve(`var ${varName} = await driver.executeScript("${script}");`);
 }
 
 async function emitPause(_, time) {


### PR DESCRIPTION
This PR aims to add advanced document manipulation commands, by also complying with browser vendor's requests about security.  
In a glance the aim is to remove access to the `Selenium` object, much like in WebDriver, scripts will be executed in the `window` context.  
- [ ] `execute script` as an alternative to `store eval`
- [ ] `store` works as an extension command (e.g. can work before `open`) fixes #226 
- [ ] warn about parameters preprocessing