### PR TITLE
add a deprecated state

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/playback.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/playback.js
@@ -124,13 +124,13 @@ function catchPlayingError(message) {
   }
 }
 
-function reportError(error) {
+function reportError(error, state = PlaybackStates.Failed) {
   const { id } = PlaybackState.runningQueue[PlaybackState.currentPlayingIndex];
   let message = error;
   if (error.message === "this.playingFrameLocations[this.currentPlayingTabId] is undefined") {
     message = "The current tab is invalid for testing (e.g. about:home), surf to a webpage before using the extension";
   }
-  PlaybackState.setCommandState(id, PlaybackStates.Failed, message);
+  PlaybackState.setCommandState(id, state, message);
 }
 
 reaction(
@@ -323,7 +323,7 @@ function doDelay() {
 }
 
 function notifyWaitDeprecation(command) {
-  reportError(`${command} is deprecated, Selenium IDE waits automatically instead`);
+  reportError(`${command} is deprecated, Selenium IDE waits automatically instead`, PlaybackStates.Deprecated);
 }
 
 function isReceivingEndError(reason) {

--- a/packages/selenium-ide/src/neo/components/TestRow/style.css
+++ b/packages/selenium-ide/src/neo/components/TestRow/style.css
@@ -96,6 +96,10 @@
   color: #E80600;
 }
 
+.test-table tbody tr.deprecated td {
+  color: #E80600;
+}
+
 .test-table tbody tr.fatal td:not(:first-child) {
   color: #E80600;
   font-weight: bold;

--- a/packages/selenium-ide/src/neo/side-effects/playback-logging.js
+++ b/packages/selenium-ide/src/neo/side-effects/playback-logging.js
@@ -74,6 +74,7 @@ export default class PlaybackLogger {
         case PlaybackStates.Undetermined:
           log.setStatus(LogTypes.Undetermined);
           break;
+        case PlaybackStates.Deprecated:
         case PlaybackStates.Failed:
         case PlaybackStates.Fatal: // eslint-disable-line no-fallthrough
           log.setStatus(LogTypes.Failure);

--- a/packages/selenium-ide/src/neo/stores/view/PlaybackState.js
+++ b/packages/selenium-ide/src/neo/stores/view/PlaybackState.js
@@ -343,6 +343,7 @@ class PlaybackState {
 }
 
 export const PlaybackStates = {
+  Deprecated: "deprecated",
   Failed: "failed",
   Fatal: "fatal",
   Passed: "passed",


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

While I tested my old script, I saw the error count.
 
![image](https://user-images.githubusercontent.com/33743343/42014260-528ccb32-7adc-11e8-8e20-de5ff3167776.png)

The test case had two errors which is the `isImplicitWait`.
But the test case was not failed.
Even the test case run correctly, I got the result failed because of `isImplicitWait`.

I thought the wait method is shown `failed` but not counted is better.