### PR TITLE
fixed error when migrating old test case which has a command

### DIFF
--- a/packages/selenium-ide/src/neo/IO/legacy/migrate.js
+++ b/packages/selenium-ide/src/neo/IO/legacy/migrate.js
@@ -117,9 +117,11 @@ export function migrateTestCase(data) {
   const sanitized = sanitizeXml(data);
   const result = JSON.parse(convert.xml2json(sanitized, { compact: true }));
   const baseUrl = result.html.head.link._attributes.href;
+  let tr = result.html.body.table.tbody.tr;
+  tr = Array.isArray(tr) ? tr : [tr];
   const test = {
     name: result.html.body.table.thead.tr.td._text,
-    commands: result.html.body.table.tbody.tr.filter(row => (row.td[0]._text && !/^wait/.test(row.td[0]._text))).map(row => (
+    commands: tr.filter(row => (row.td[0]._text && !/^wait/.test(row.td[0]._text))).map(row => (
       {
         command: row.td[0]._text && row.td[0]._text.replace("AndWait", ""),
         target: xmlunescape(parseTarget(row.td[1])),

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/IDE_test_10.html
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/IDE_test_10.html
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="https://stage.local.com/" />
+<title>Log in as test user</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">A command</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/IO/legacy/migrate.spec.js
@@ -74,6 +74,11 @@ describe("selenium test case migration", () => {
     const { test } = migrateTestCase(file);
     expect(test.commands.length).toBe(2);
   });
+  it("should import a test case with a command in it", () => {
+    const file = fs.readFileSync(path.join(__dirname, "IDE_test_10.html")).toString();
+    const { test } = migrateTestCase(file);
+    expect(test.commands.length).toBe(1);
+  });
 });
 
 describe("selenium suite migration", () => {


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

While I test an old test case, I got an error message.
The test case is a test case which has one command.
I don't know if you feel this is needed or not, I think this checking is not bad.

[oneCommand.zip](https://github.com/SeleniumHQ/selenium-ide/files/2168685/oneCommand.zip) is not the test case which I used, but I attach a test case which has one command.

And the `loadProject` function doesn't seem to work well about an old test case at the master branch.
