### PR TITLE
alternative of #283

### DIFF
--- a/packages/selenium-ide/src/neo/components/CommandForm/style.css
+++ b/packages/selenium-ide/src/neo/components/CommandForm/style.css
@@ -2,10 +2,6 @@
     margin: 15px 8px;
 }
 
-.command-form form> * {
-    max-width: 480px;
-}
-
 .command-form .form-input:first-child> div {
     display: flex!important;
 }


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

apply #283 