### PR TITLE
fixed spelling mistake at selectWinodw Commnad

### DIFF
--- a/packages/selenium-ide/src/neo/models/Command.js
+++ b/packages/selenium-ide/src/neo/models/Command.js
@@ -509,7 +509,7 @@ class CommandList {
     [ "selectWindow", {
       name: "select window",
       description: "Selects a popup window using a window locator. Once a popup \
-                    window has been selected, all commands wll go to that window. \
+                    window has been selected, all commands will go to that window. \
                     To select the main window again, use null as the target. \
                     Window locators provide different ways of specifying the window \
                     object: by title or by generated id.",


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
