### PR TITLE
snapshot plugins commands

### DIFF
--- a/packages/selenium-ide/src/neo/IO/filesystem.js
+++ b/packages/selenium-ide/src/neo/IO/filesystem.js
@@ -70,9 +70,9 @@ export function saveProject(_project) {
 }
 
 function downloadProject(project) {
-  return exportProject(project).then(code => {
-    if (code) {
-      project.code = code;
+  return exportProject(project).then(snapshot => {
+    if (snapshot) {
+      project.snapshot = snapshot;
       Object.assign(project, Manager.emitDependencies());
     }
     return browser.downloads.download({

--- a/packages/selenium-ide/src/neo/IO/filesystem.js
+++ b/packages/selenium-ide/src/neo/IO/filesystem.js
@@ -71,8 +71,10 @@ export function saveProject(_project) {
 
 function downloadProject(project) {
   return exportProject(project).then(code => {
-    project.code = code;
-    Object.assign(project, Manager.emitDependencies());
+    if (code) {
+      project.code = code;
+      Object.assign(project, Manager.emitDependencies());
+    }
     return browser.downloads.download({
       filename: project.name + ".side",
       url: createBlob("application/json", beautify(JSON.stringify(project), { indent_size: 2 })),
@@ -84,7 +86,7 @@ function downloadProject(project) {
 
 function exportProject(project) {
   return Manager.validatePluginExport(project).then(() => {
-    return Selianize(project, { silenceErrors: true }).catch(err => {
+    return Selianize(project, { silenceErrors: true, skipStdLibEmitting: true }).catch(err => {
       const markdown = ParseError(err && err.message || err);
       ModalState.showAlert({
         title: "Error saving project",

--- a/packages/selenium-side-runner/package.json
+++ b/packages/selenium-side-runner/package.json
@@ -35,6 +35,7 @@
     "js-yaml": "^3.10.0",
     "rimraf": "^2.6.2",
     "selenium-webdriver": "^3.6.0",
+    "selianize": "*",
     "winston": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/selenium-side-runner/src/index.js
+++ b/packages/selenium-side-runner/src/index.js
@@ -120,7 +120,7 @@ function runProject(project) {
     dependencies: project.dependencies || {}
   }));
 
-  return Selianize(project, { silenceErrors: true }).then((code) => {
+  return Selianize(project, { silenceErrors: true }, project.snapshot).then((code) => {
     const tests = code.tests.reduce((tests, test) => {
       return tests += test.code;
     }, "const tests = {};").concat("module.exports = tests;");

--- a/packages/selianize/__tests__/command.spec.js
+++ b/packages/selianize/__tests__/command.spec.js
@@ -673,4 +673,13 @@ describe("command code emitter", () => {
     };
     return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).resolves.toEqual({ skipped: true });
   });
+  it("should return the snapshot when an unknown command is being emitted with snapshot sent", () => {
+    const command = {
+      command: "doesntExist",
+      target: "",
+      value: ""
+    };
+    const snapshot = "this commands snapshot";
+    return expect(CommandEmitter.emit(command, undefined, snapshot)).resolves.toBe(snapshot);
+  });
 });

--- a/packages/selianize/__tests__/command.spec.js
+++ b/packages/selianize/__tests__/command.spec.js
@@ -656,10 +656,21 @@ describe("command code emitter", () => {
   });
   it("should throw an error for an invalid non-stdlib command even when skipStdLibEmitting is set", () => {
     const command = {
+      command: "errorCommand",
+      target: "",
+      value: ""
+    };
+    registerEmitter(command.command, () => {
+      throw new Error("an error occurred");
+    });
+    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).rejects.toThrow("an error occurred");
+  });
+  it("should not throw an error for an unknown command when skipStdLibEmitting is set", () => {
+    const command = {
       command: "doesntExist",
       target: "",
       value: ""
     };
-    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).rejects.toThrow(`Unknown command ${command.command}`);
+    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).resolves.toEqual({ skipped: true });
   });
 });

--- a/packages/selianize/__tests__/command.spec.js
+++ b/packages/selianize/__tests__/command.spec.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import CommandEmitter from "../src/command";
+import CommandEmitter, { registerEmitter } from "../src/command";
 import { Commands } from "../../selenium-ide/src/neo/models/Command";
 
 describe("command code emitter", () => {
@@ -636,5 +636,30 @@ describe("command code emitter", () => {
         }
       }).not.toThrow();
     });
+  });
+  it("should skip emitting stdlib command when skipStdLibEmitting is set", () => {
+    const command = {
+      command: "open",
+      target: "/",
+      value: ""
+    };
+    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).resolves.toEqual({ skipped: true });
+  });
+  it("should emit a snapshot for a non-stdlib command when skipStdLibEmitting is set", () => {
+    const command = {
+      command: "aNewCommand",
+      target: "",
+      value: ""
+    };
+    registerEmitter(command.command, () => ("new command code"));
+    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).resolves.toBe("new command code");
+  });
+  it("should throw an error for an invalid non-stdlib command even when skipStdLibEmitting is set", () => {
+    const command = {
+      command: "doesntExist",
+      target: "",
+      value: ""
+    };
+    return expect(CommandEmitter.emit(command, { skipStdLibEmitting: true })).rejects.toThrow(`Unknown command ${command.command}`);
   });
 });

--- a/packages/selianize/__tests__/command.spec.js
+++ b/packages/selianize/__tests__/command.spec.js
@@ -41,7 +41,7 @@ describe("command code emitter", () => {
       target: "/",
       value: ""
     };
-    return expect(CommandEmitter.emit(command)).resolves.toBe(`await driver.get(BASE_URL + "${command.target}");`);
+    return expect(CommandEmitter.emit(command)).resolves.toBe(`await driver.get((new URL("${command.target}", BASE_URL)).href);`);
   });
   it("should emit `open` with absolute url", () => {
     const command = {

--- a/packages/selianize/__tests__/configuration.spec.js
+++ b/packages/selianize/__tests__/configuration.spec.js
@@ -22,7 +22,7 @@ describe("configuration code emitter", () => {
     const project = {
       url: "http://www.seleniumhq.org"
     };
-    return expect(ConfigurationEmitter.emit(project)).resolves.toBe(`global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};`);
+    return expect(ConfigurationEmitter.emit(project)).resolves.toBe(`global.URL = require('url').URL;global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};`);
   });
   it("should skip emitting project configuration when skipStdLibEmitting is set and there are no config hooks", () => {
     const project = {
@@ -37,7 +37,7 @@ describe("configuration code emitter", () => {
       url: "http://www.seleniumhq.org"
     };
     const snapshot = "extra global config";
-    return expect(ConfigurationEmitter.emit(project, undefined, snapshot)).resolves.toBe(`global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${snapshot}`);
+    return expect(ConfigurationEmitter.emit(project, undefined, snapshot)).resolves.toBe(`global.URL = require('url').URL;global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${snapshot}`);
   });
   it("should emit a snapshot of the hooks when skipStdLibEmitting is set", () => {
     const project = {

--- a/packages/selianize/__tests__/configuration.spec.js
+++ b/packages/selianize/__tests__/configuration.spec.js
@@ -32,6 +32,13 @@ describe("configuration code emitter", () => {
       skipped: true
     });
   });
+  it("should append the configuration snapshot to the config", () => {
+    const project = {
+      url: "http://www.seleniumhq.org"
+    };
+    const snapshot = "extra global config";
+    return expect(ConfigurationEmitter.emit(project, undefined, snapshot)).resolves.toBe(`global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${snapshot}`);
+  });
   it("should emit a snapshot of the hooks when skipStdLibEmitting is set", () => {
     const project = {
       url: "http://www.seleniumhq.org"

--- a/packages/selianize/__tests__/configuration.spec.js
+++ b/packages/selianize/__tests__/configuration.spec.js
@@ -24,4 +24,21 @@ describe("configuration code emitter", () => {
     };
     return expect(ConfigurationEmitter.emit(project)).resolves.toBe(`global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};`);
   });
+  it("should skip emitting project configuration when skipStdLibEmitting is set and there are no config hooks", () => {
+    const project = {
+      url: "http://www.seleniumhq.org"
+    };
+    return expect(ConfigurationEmitter.emit(project, { skipStdLibEmitting: true })).resolves.toEqual({
+      skipped: true
+    });
+  });
+  it("should emit a snapshot of the hooks when skipStdLibEmitting is set", () => {
+    const project = {
+      url: "http://www.seleniumhq.org"
+    };
+    ConfigurationEmitter.registerHook(() => ("some config code"));
+    return expect(ConfigurationEmitter.emit(project, { skipStdLibEmitting: true })).resolves.toEqual({
+      snapshot: "some config code"
+    });
+  });
 });

--- a/packages/selianize/__tests__/index.spec.js
+++ b/packages/selianize/__tests__/index.spec.js
@@ -29,7 +29,7 @@ describe("Selenium code serializer", () => {
     const hook = jest.fn();
     hook.mockReturnValue(Promise.resolve("some code the the top"));
     RegisterConfigurationHook(hook);
-    return expect((await Selianize(project)).suites[0].code).toMatch(/some code the the top/);
+    return expect((await Selianize(project)).globalConfig).toMatch(/some code the the top/);
   });
   it("should register a suite emitter hook", async () => {
     const project = JSON.parse(fs.readFileSync(path.join(__dirname, "test-files", "project-3-single-test.side")));

--- a/packages/selianize/__tests__/suite.spec.js
+++ b/packages/selianize/__tests__/suite.spec.js
@@ -26,7 +26,9 @@ describe("suite emitter", () => {
       timeout: "30",
       tests: []
     };
-    return expect(SuiteEmitter.emit(suite, {})).resolves.toBe(`jest.setTimeout(30000);describe("${suite.name}", () => {});`);
+    return expect(SuiteEmitter.emit(suite, {})).resolves.toEqual({
+      code: `jest.setTimeout(30000);describe("${suite.name}", () => {});`
+    });
   });
   it("should emit a suite with a single empty test", async () => {
     const tests = {
@@ -44,7 +46,9 @@ describe("suite emitter", () => {
     };
     return expect(SuiteEmitter.emit(suite, {
       1: await TestCaseEmitter.emit(tests["1"])
-    })).resolves.toBe(`jest.setTimeout(30000);describe("${suite.name}", () => {it("${tests["1"].name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});`);
+    })).resolves.toEqual({
+      code: `jest.setTimeout(30000);describe("${suite.name}", () => {it("${tests["1"].name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});`
+    });
   });
   it("should emit a suite with multiple empty tests", async () => {
     const tests = {
@@ -74,7 +78,9 @@ describe("suite emitter", () => {
       1: await TestCaseEmitter.emit(tests["1"]),
       2: await TestCaseEmitter.emit(tests["2"]),
       3: await TestCaseEmitter.emit(tests["3"])
-    })).resolves.toBe(`jest.setTimeout(30000);describe("${suite.name}", () => {it("${tests["1"].name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it("${tests["2"].name}", async () => {await tests.second_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it("${tests["3"].name}", async () => {await tests.third_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});`);
+    })).resolves.toEqual({
+      code: `jest.setTimeout(30000);describe("${suite.name}", () => {it("${tests["1"].name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it("${tests["2"].name}", async () => {await tests.second_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it("${tests["3"].name}", async () => {await tests.third_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});`
+    });
   });
   it("should emit a parallel suite", async () => {
     const tests = {
@@ -118,5 +124,33 @@ describe("suite emitter", () => {
         name: tests["3"].name,
         code: `jest.setTimeout(30000);test("${tests["3"].name}", async () => {await tests.third_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});`
       }]);
+  });
+  it("should skip emitting when skipStdLibEmitting is set and no hooks are registered", () => {
+    const suite = {
+      id: "1",
+      name: "example suite",
+      timeout: "30",
+      tests: []
+    };
+    return expect(SuiteEmitter.emit(suite, {}, { skipStdLibEmitting: true })).resolves.toEqual({ skipped: true });
+  });
+  it("should emit a snapshot of the hooks when skipStdLibEmitting is set and hooks are registered", () => {
+    const suite = {
+      id: "1",
+      name: "example suite",
+      timeout: "30",
+      tests: []
+    };
+    SuiteEmitter.registerHook(() => ({
+      beforeAll: "beforeAll code",
+      before: "before code",
+      after: "after code",
+      afterAll: "afterAll code"
+    }));
+    return expect(SuiteEmitter.emit(suite, {}, { skipStdLibEmitting: true })).resolves.toEqual({
+      snapshot: {
+        hook: "beforeAll(async () => {beforeAll code});beforeEach(async () => {before code});afterEach(async () => {after code});afterAll(async () => {afterAll code});"
+      }
+    });
   });
 });

--- a/packages/selianize/__tests__/suite.spec.js
+++ b/packages/selianize/__tests__/suite.spec.js
@@ -153,4 +153,18 @@ describe("suite emitter", () => {
       }
     });
   });
+  it("should append the snapshot to the normal hooks", () => {
+    const suite = {
+      id: "1",
+      name: "example suite",
+      timeout: "30",
+      tests: []
+    };
+    const snapshot = {
+      hook: "hook results"
+    };
+    return expect(SuiteEmitter.emit(suite, {}, undefined, snapshot)).resolves.toEqual({
+      code: "jest.setTimeout(30000);describe(\"example suite\", () => {beforeAll(async () => {beforeAll code});beforeEach(async () => {before code});afterEach(async () => {after code});afterAll(async () => {afterAll code});hook results});"
+    });
+  });
 });

--- a/packages/selianize/__tests__/testcase.spec.js
+++ b/packages/selianize/__tests__/testcase.spec.js
@@ -46,7 +46,7 @@ describe("test case code emitter", () => {
       id: "1",
       name: "example test case",
       test: `it("${test.name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});`,
-      function: `tests.example_test_case = async function example_test_case(driver, vars, opts) {await driver.get(BASE_URL + "${test.commands[0].target}");}`
+      function: `tests.example_test_case = async function example_test_case(driver, vars, opts) {await driver.get((new URL("${test.commands[0].target}", BASE_URL)).href);}`
     });
   });
   it("should emit a test with multiple commands", () => {
@@ -75,7 +75,7 @@ describe("test case code emitter", () => {
       id: "1",
       name: "example test case",
       test: `it("${test.name}", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});`,
-      function: `tests.example_test_case = async function example_test_case(driver, vars, opts) {await driver.get(BASE_URL + "${test.commands[0].target}");await driver.get(BASE_URL + "${test.commands[1].target}");await driver.get(BASE_URL + "${test.commands[2].target}");}`
+      function: `tests.example_test_case = async function example_test_case(driver, vars, opts) {await driver.get((new URL("${test.commands[0].target}", BASE_URL)).href);await driver.get((new URL("${test.commands[1].target}", BASE_URL)).href);await driver.get((new URL("${test.commands[2].target}", BASE_URL)).href);}`
     });
   });
   it("should reject a test with failed commands", () => {

--- a/packages/selianize/__tests__/testcase.spec.js
+++ b/packages/selianize/__tests__/testcase.spec.js
@@ -188,6 +188,33 @@ describe("test case code emitter", () => {
       }
     });
   });
+  it("should send the snapshot to the command", () => {
+    const test = {
+      id: "1",
+      name: "example test case",
+      commands: [
+        {
+          id: "2",
+          command: "anUnknownCommand",
+          target: "",
+          value: ""
+        }
+      ]
+    };
+    const snapshot = {
+      commands: {
+        "2": "command code"
+      },
+      setupHooks: [],
+      teardownHooks: []
+    };
+    expect(TestCaseEmitter.emit(test, undefined, snapshot)).resolves.toEqual({
+      id: "1",
+      name: "example test case",
+      test: "it(\"example test case\", async () => {await tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});",
+      function: "tests.example_test_case = async function example_test_case(driver, vars, opts) {command code}"
+    });
+  });
   it("should emit a snapshot for a test case with setup and teardown hooks when skipStdLibEmitting is set", () => {
     const test = {
       id: "1",
@@ -205,6 +232,24 @@ describe("test case code emitter", () => {
         setupHooks: ["setup code"],
         teardownHooks: ["teardown code"]
       }
+    });
+  });
+  it("should append the snapshot of the setup and teardown hooks to the test case", () => {
+    const test = {
+      id: "1",
+      name: "example test case",
+      commands: []
+    };
+    const snapshot = {
+      commands: {},
+      setupHooks: ["more setup"],
+      teardownHooks: ["more teardown"]
+    };
+    expect(TestCaseEmitter.emit(test, undefined, snapshot)).resolves.toEqual({
+      id: "1",
+      name: "example test case",
+      test: "it(\"example test case\", async () => {setup codemore setupawait tests.example_test_case(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});teardown codemore teardown});",
+      function: "tests.example_test_case = async function example_test_case(driver, vars, opts) {}"
     });
   });
 });

--- a/packages/selianize/src/command.js
+++ b/packages/selianize/src/command.js
@@ -97,7 +97,7 @@ const emitters = {
   setSpeed: skip
 };
 
-export function emit(command, options = config) {
+export function emit(command, options = config, snapshot) {
   return new Promise(async (res, rej) => {
     if (emitters[command.command]) {
       if (options.skipStdLibEmitting && !emitters[command.command].isAdditional)
@@ -113,6 +113,8 @@ export function emit(command, options = config) {
     } else {
       if (!command.command) {
         res();
+      } else if (snapshot) {
+        res(snapshot);
       } else {
         rej(new Error(`Unknown command ${command.command}`));
       }

--- a/packages/selianize/src/command.js
+++ b/packages/selianize/src/command.js
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import config from "./config";
 import LocationEmitter from "./location";
 import SelectionEmitter from "./selection";
 import { convertToSnake } from "./utils";
@@ -96,9 +97,11 @@ const emitters = {
   setSpeed: skip
 };
 
-export function emit(command) {
+export function emit(command, options = config) {
   return new Promise(async (res, rej) => {
     if (emitters[command.command]) {
+      if (options.skipStdLibEmitting && !emitters[command.command].isAdditional)
+        return res({ skipped: true });
       try {
         let result = await emitters[command.command](preprocessParameter(command.target), preprocessParameter(command.value));
         res(result);
@@ -123,9 +126,10 @@ function preprocessParameter(param) {
   return param ? param.replace(/\$\{/g, "${vars.") : param;
 }
 
-function registerEmitter(command, emitter) {
+export function registerEmitter(command, emitter) {
   if (!canEmit(command)) {
     emitters[command] = emitter;
+    emitters[command].isAdditional = true;
   }
 }
 

--- a/packages/selianize/src/command.js
+++ b/packages/selianize/src/command.js
@@ -108,6 +108,8 @@ export function emit(command, options = config) {
       } catch (e) {
         rej(e);
       }
+    } else if (options.skipStdLibEmitting) {
+      res({ skipped: true });
     } else {
       if (!command.command) {
         res();

--- a/packages/selianize/src/command.js
+++ b/packages/selianize/src/command.js
@@ -144,7 +144,7 @@ export default {
 };
 
 function emitOpen(target) {
-  const url = /^(file|http|https):\/\//.test(target) ? `"${target}"` : `BASE_URL + "${target}"`;
+  const url = /^(file|http|https):\/\//.test(target) ? `"${target}"` : `(new URL("${target}", BASE_URL)).href`;
   return Promise.resolve(`await driver.get(${url});`);
 }
 

--- a/packages/selianize/src/config.js
+++ b/packages/selianize/src/config.js
@@ -16,6 +16,7 @@
 // under the License.
 
 export default {
-  silenceErrors: false
+  silenceErrors: false,
+  skipStdLibEmitting: false
 };
 

--- a/packages/selianize/src/configuration.js
+++ b/packages/selianize/src/configuration.js
@@ -22,7 +22,7 @@ const hooks = [];
 export async function emit(project, options = config, snapshot) {
   const configHooks = (await Promise.all(hooks.map((hook) => hook({ name: project.name })))).join("");
   if (!options.skipStdLibEmitting) {
-    return `global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${configHooks}${snapshot ? snapshot : ""}`;
+    return `global.URL = require('url').URL;global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${configHooks}${snapshot ? snapshot : ""}`;
   } else {
     if (configHooks) {
       return {

--- a/packages/selianize/src/configuration.js
+++ b/packages/selianize/src/configuration.js
@@ -19,10 +19,10 @@ import config from "./config";
 
 const hooks = [];
 
-export async function emit(project, options = config) {
+export async function emit(project, options = config, snapshot) {
   const configHooks = (await Promise.all(hooks.map((hook) => hook({ name: project.name })))).join("");
   if (!options.skipStdLibEmitting) {
-    return `global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${configHooks}`;
+    return `global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${configHooks}${snapshot ? snapshot : ""}`;
   } else {
     if (configHooks) {
       return {

--- a/packages/selianize/src/configuration.js
+++ b/packages/selianize/src/configuration.js
@@ -15,10 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import config from "./config";
+
 const hooks = [];
 
-export async function emit(project) {
-  return `global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${(await Promise.all(hooks.map((hook) => hook({ name: project.name })))).join("")}`;
+export async function emit(project, options = config) {
+  const configHooks = (await Promise.all(hooks.map((hook) => hook({ name: project.name })))).join("");
+  if (!options.skipStdLibEmitting) {
+    return `global.BASE_URL = configuration.baseUrl || '${project.url}';let vars = {};${configHooks}`;
+  } else {
+    if (configHooks) {
+      return {
+        snapshot: configHooks
+      };
+    } else {
+      return {
+        skipped: true
+      };
+    }
+  }
 }
 
 function registerHook(hook) {

--- a/packages/selianize/src/suite.js
+++ b/packages/selianize/src/suite.js
@@ -17,7 +17,9 @@
 
 const hooks = [];
 
-export function emit(suite, tests) {
+import config from "./config";
+
+export function emit(suite, tests, options = config) {
   return new Promise(async (res, rej) => { // eslint-disable-line no-unused-vars
     const hookResults = (await Promise.all(hooks.map((hook) => hook({ name: suite.name })))).reduce((code, result) => (
       code
@@ -26,28 +28,39 @@ export function emit(suite, tests) {
       + (result.after ? `afterEach(async () => {${result.after}});` : "")
       + (result.afterAll ? `afterAll(async () => {${result.afterAll}});` : "")
     ), "");
-    let testsCode = (await Promise.all(suite.tests.map(testId => (
-      tests[testId]
-    )).map((test) => (test.test))));
 
-    if (suite.parallel) {
-      testsCode = testsCode.map((code, index) => ({
-        name: tests[suite.tests[index]].name,
-        code: code.replace(/^it/, `jest.setTimeout(${suite.timeout * 1000});test`)
-      }));
-      return res(testsCode);
+    if (!options.skipStdLibEmitting) {
+      let testsCode = (await Promise.all(suite.tests.map(testId => (
+        tests[testId]
+      )).map((test) => (test.test))));
+
+      if (suite.parallel) {
+        testsCode = testsCode.map((code, index) => ({
+          name: tests[suite.tests[index]].name,
+          code: code.replace(/^it/, `jest.setTimeout(${suite.timeout * 1000});test`)
+        }));
+        return res(testsCode);
+      }
+
+      let result = `jest.setTimeout(${suite.timeout * 1000});describe("${suite.name}", () => {${hookResults}`;
+
+      result += testsCode.join("");
+
+      result += "});";
+      res({
+        code: result
+      });
+    } else {
+      res(hookResults ? {
+        snapshot: {
+          hook: hookResults
+        }
+      } : { skipped: true });
     }
-
-    let result = `jest.setTimeout(${suite.timeout * 1000});describe("${suite.name}", () => {${hookResults}`;
-
-    result += testsCode.join("");
-
-    result += "});";
-    res(result);
   });
 }
 
-function registerHook(hook) {
+export function registerHook(hook) {
   hooks.push(hook);
 }
 

--- a/packages/selianize/src/suite.js
+++ b/packages/selianize/src/suite.js
@@ -19,7 +19,7 @@ const hooks = [];
 
 import config from "./config";
 
-export function emit(suite, tests, options = config) {
+export function emit(suite, tests, options = config, snapshot) {
   return new Promise(async (res, rej) => { // eslint-disable-line no-unused-vars
     const hookResults = (await Promise.all(hooks.map((hook) => hook({ name: suite.name })))).reduce((code, result) => (
       code
@@ -42,7 +42,7 @@ export function emit(suite, tests, options = config) {
         return res(testsCode);
       }
 
-      let result = `jest.setTimeout(${suite.timeout * 1000});describe("${suite.name}", () => {${hookResults}`;
+      let result = `jest.setTimeout(${suite.timeout * 1000});describe("${suite.name}", () => {${hookResults}${snapshot ? snapshot.hook : ""}`;
 
       result += testsCode.join("");
 

--- a/tests/examples/check-examples.side
+++ b/tests/examples/check-examples.side
@@ -80,17 +80,5 @@
   }],
   "urls": ["https://en.wikipedia.org/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "checks",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"checks\", () => {it(\"check-examples\", async () => {await tests.check_examples(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "check-examples",
-      "code": "tests.check_examples = async function check_examples(driver, vars) {await driver.get(BASE_URL + \"/check.html\");await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await driver.findElement(By.id(`f`)).then(element => { element.isSelected().then(selected => {if(!selected) { element.click();}}); });await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.toBeChecked();await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await driver.findElement(By.id(`f`)).then(element => { element.isSelected().then(selected => {if(!selected) { element.click();}}); });await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.toBeChecked();await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await driver.findElement(By.id(`f`)).then(element => { element.isSelected().then(selected => {if(selected) { element.click();}}); });await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.not.toBeChecked();await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await driver.findElement(By.id(`f`)).then(element => { element.isSelected().then(selected => {if(selected) { element.click();}}); });await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.not.toBeChecked();}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }

--- a/tests/examples/execute-script.side
+++ b/tests/examples/execute-script.side
@@ -77,20 +77,5 @@
   }],
   "urls": ["https://en.wikipedia.org/", "http://localhost:5000/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "execute script",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80/';let vars = {};jest.setTimeout(300000);describe(\"execute script\", () => {it(\"execute async script\", async () => {await tests.execute_async_script(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"execute script\", async () => {await tests.execute_script(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "execute script",
-      "code": "tests.execute_script = async function execute_script(driver, vars) {await driver.get(BASE_URL + \"/value.html\");vars[\"sync\"] = await driver.executeScript(`return \"sync\"`);await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await driver.findElement(By.id(`v`)).then(element => {element.clear().then(() => {element.sendKeys(`${vars.sync}`);});});await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await expect(driver.findElement(By.id(`v`))).resolves.toHaveValue(`sync`);}"
-    }, {
-      "name": "execute async script",
-      "code": "tests.execute_async_script = async function execute_async_script(driver, vars) {await driver.get(BASE_URL + \"/value.html\");vars[\"async\"] = await driver.executeAsyncScript(`var callback = arguments[arguments.length - 1];return new Promise((r) => {setTimeout(() => {r(\"async\")}, 500)}).then(callback).catch(callback);`);await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await driver.findElement(By.id(`v`)).then(element => {element.clear().then(() => {element.sendKeys(`${vars.async}`);});});await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await expect(driver.findElement(By.id(`v`))).resolves.toHaveValue(`async`);}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }

--- a/tests/examples/nginx-examples.side
+++ b/tests/examples/nginx-examples.side
@@ -263,7 +263,7 @@
     }, {
       "id": "62aba19e-1df8-453a-adf5-5b66d19efcc1",
       "comment": "",
-      "command": "webdriverChooseOkOnNextConfirmation",
+      "command": "webdriverChooseOkOnVisibleConfirmation",
       "target": "",
       "targets": [],
       "value": ""
@@ -298,7 +298,7 @@
     }, {
       "id": "f60f098f-ef36-4f35-9947-9dfc1d713d9f",
       "comment": "",
-      "command": "webdriverChooseCancelOnNextConfirmation",
+      "command": "webdriverChooseCancelOnVisibleConfirmation",
       "target": "",
       "targets": [],
       "value": ""
@@ -344,7 +344,7 @@
     }, {
       "id": "14904a55-9a9b-4982-8763-49563c849493",
       "comment": "",
-      "command": "webdriverChooseCancelOnNextPrompt",
+      "command": "webdriverChooseCancelOnVisiblePrompt",
       "target": "",
       "targets": [],
       "value": ""
@@ -379,7 +379,7 @@
     }, {
       "id": "879ac9d9-32da-4ae3-a124-75c09aae52b3",
       "comment": "",
-      "command": "webdriverAnswerOnNextPrompt",
+      "command": "webdriverAnswerOnVisiblePrompt",
       "target": "",
       "targets": [],
       "value": ""
@@ -414,7 +414,7 @@
     }, {
       "id": "f6ccc7a8-e6b1-43c4-b361-d1b7432ea83e",
       "comment": "",
-      "command": "webdriverAnswerOnNextPrompt",
+      "command": "webdriverAnswerOnVisiblePrompt",
       "target": "selenium",
       "targets": [],
       "value": ""
@@ -451,46 +451,5 @@
   }],
   "urls": ["https://en.wikipedia.org/", "http://localhost:5000/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "inputs",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"inputs\", () => {it(\"input editable\", async () => {await tests.input_editable(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"input type checkbox\", async () => {await tests.input_type_checkbox(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"input type text\", async () => {await tests.input_type_text(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"select\", async () => {await tests.select(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }, {
-      "name": "waits",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"waits\", () => {it(\"wait implicit\", async () => {await tests.wait_implicit(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }, {
-      "name": "popups",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"popups\", () => {it(\"popup alert\", async () => {await tests.popup_alert(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"popup confirmation\", async () => {await tests.popup_confirmation(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"popup prompt\", async () => {await tests.popup_prompt(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "input type text",
-      "code": "tests.input_type_text = async function input_type_text(driver, vars) {await driver.get(BASE_URL + \"/value.html\");await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await expect(driver.findElement(By.id(`v`))).resolves.toHaveValue(`test`);await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await driver.findElement(By.id(`v`)).then(element => {element.clear().then(() => {element.sendKeys(`selenium`);});});await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await expect(driver.findElement(By.id(`v`))).resolves.toHaveValue(`selenium`);await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await driver.findElement(By.id(`v`)).then(element => {driver.actions().click(element).sendKeys(`-ide`).perform();});await driver.wait(until.elementLocated(By.id(`v`)), configuration.timeout);await expect(driver.findElement(By.id(`v`))).resolves.toHaveValue(`selenium-ide`);}"
-    }, {
-      "name": "input type checkbox",
-      "code": "tests.input_type_checkbox = async function input_type_checkbox(driver, vars) {await driver.get(BASE_URL + \"/check.html\");await driver.wait(until.elementLocated(By.id(`t`)), configuration.timeout);await expect(driver.findElement(By.id(`t`))).resolves.toBeChecked();await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.not.toBeChecked();await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await driver.findElement(By.id(`f`)).then(element => {driver.actions().click(element).perform();});await driver.wait(until.elementLocated(By.id(`f`)), configuration.timeout);await expect(driver.findElement(By.id(`f`))).resolves.toBeChecked();}"
-    }, {
-      "name": "input editable",
-      "code": "tests.input_editable = async function input_editable(driver, vars) {await driver.get(BASE_URL + \"/editable.html\");await driver.wait(until.elementLocated(By.id(`d`)), configuration.timeout);await expect(driver.findElement(By.id(`d`))).resolves.not.toBeEditable();await driver.wait(until.elementLocated(By.id(`r`)), configuration.timeout);await expect(driver.findElement(By.id(`r`))).resolves.not.toBeEditable();await driver.wait(until.elementLocated(By.id(`e`)), configuration.timeout);await expect(driver.findElement(By.id(`e`))).resolves.toBeEditable();await driver.wait(until.elementLocated(By.id(`e`)), configuration.timeout);await driver.findElement(By.id(`e`)).then(element => {element.clear().then(() => {element.sendKeys(`selenium`);});});await driver.wait(until.elementLocated(By.id(`e`)), configuration.timeout);await expect(driver.findElement(By.id(`e`))).resolves.toHaveValue(`selenium`);}"
-    }, {
-      "name": "select",
-      "code": "tests.select = async function select(driver, vars) {await driver.get(BASE_URL + \"/select.html\");await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await expect(driver.findElement(By.id(`select`))).resolves.toHaveSelectedValue(`1`);await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await driver.findElement(By.id(`select`)).then(element => {element.findElement(By.xpath(`//option[. = 'Two']`)).then(option => {option.click();});});await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await expect(driver.findElement(By.id(`select`))).resolves.toHaveSelectedValue(`2`);}"
-    }, {
-      "name": "wait implicit",
-      "code": "tests.wait_implicit = async function wait_implicit(driver, vars) {await driver.get(BASE_URL + \"/wait/implicit.html\");await expect(driver.findElements(By.id(`t`))).resolves.not.toBePresent();await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.wait(until.elementLocated(By.id(`t`)), configuration.timeout);await expect(driver.findElement(By.id(`t`))).resolves.toHaveText(`selenium`);}"
-    }, {
-      "name": "popup alert",
-      "code": "tests.popup_alert = async function popup_alert(driver, vars) {await driver.get(BASE_URL + \"/popup/alert.html\");await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);alert.accept();});});await driver.getTitle().then(title => {expect(title).toBe(`changed`);});}"
-    }, {
-      "name": "popup confirmation",
-      "code": "tests.popup_confirmation = async function popup_confirmation(driver, vars) {await driver.get(BASE_URL + \"/popup/confirm.html\");await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);});});await driver.switchTo().alert().then(alert => {alert.accept();});await driver.getTitle().then(title => {expect(title).toBe(`ok`);});await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);});});await driver.switchTo().alert().then(alert => {alert.dismiss();});await driver.getTitle().then(title => {expect(title).toBe(`cancel`);});}"
-    }, {
-      "name": "popup prompt",
-      "code": "tests.popup_prompt = async function popup_prompt(driver, vars) {await driver.get(BASE_URL + \"/popup/prompt.html\");await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);});});await driver.switchTo().alert().then(alert => {alert.dismiss();});await driver.getTitle().then(title => {expect(title).toBe(`cancel`);});await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);});});await driver.switchTo().alert().then(alert => {alert.sendKeys(``).then(() => {alert.accept();});});await driver.getTitle().then(title => {expect(title).toBe(`empty`);});await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {driver.actions().click(element).perform();});await driver.switchTo().alert().then(alert => {alert.getText().then(text => {expect(text).toBe(`test`);});});await driver.switchTo().alert().then(alert => {alert.sendKeys(`selenium`).then(() => {alert.accept();});});await driver.getTitle().then(title => {expect(title).toBe(`selenium`);});}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }

--- a/tests/examples/select-examples.side
+++ b/tests/examples/select-examples.side
@@ -70,20 +70,5 @@
   }],
   "urls": ["https://en.wikipedia.org/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "select",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"select\", () => {it(\"select-verify-labels\", async () => {await tests.select_verify_labels(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"select strategies\", async () => {await tests.select_strategies(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "select-verify-labels",
-      "code": "tests.select_verify_labels = async function select_verify_labels(driver, vars) {await driver.get(BASE_URL + \"/select.html\");await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await driver.findElement(By.id(`select`)).then(element => {element.getAttribute(\"value\").then(selectedValue => {element.findElement(By.xpath('option[@value=\"'+selectedValue+'\"]')).then(selectedOption => {selectedOption.getText().then(selectedLabel => {expect(selectedLabel).toBe(`One`);});});});});await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await driver.findElement(By.id(`select`)).then(element => {element.getAttribute(\"value\").then(selectedValue => {element.findElement(By.xpath('option[@value=\"'+selectedValue+'\"]')).then(selectedOption => {selectedOption.getText().then(selectedLabel => {expect(selectedLabel).toBe(`One`);});});});});}"
-    }, {
-      "name": "select strategies",
-      "code": "tests.select_strategies = async function select_strategies(driver, vars) {await driver.get(BASE_URL + \"/select.html\");vars[\"label\"] = `Two`;await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await driver.findElement(By.id(`select`)).then(element => {element.findElement(By.xpath(`//option[. = '${vars.label}']`)).then(option => {option.click();});});await driver.wait(until.elementLocated(By.id(`select`)), configuration.timeout);await driver.findElement(By.id(`select`)).then(element => {element.getAttribute(\"value\").then(selectedValue => {element.findElement(By.xpath('option[@value=\"'+selectedValue+'\"]')).then(selectedOption => {selectedOption.getText().then(selectedLabel => {expect(selectedLabel).toBe(`Two`);});});});});}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }

--- a/tests/examples/store-examples.side
+++ b/tests/examples/store-examples.side
@@ -98,20 +98,5 @@
   }],
   "urls": ["https://en.wikipedia.org/", "http://localhost:5000/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "store",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"store\", () => {it(\"attributes\", async () => {await tests.attributes(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});it(\"xpath count\", async () => {await tests.xpath_count(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "attributes",
-      "code": "tests.attributes = async function attributes(driver, vars) {await driver.get(BASE_URL + \"/store/attributes.html\");await driver.wait(until.elementLocated(By.id(`test-id-1`)), configuration.timeout);await driver.findElement(By.id(`test-id-1`)).then(element => element.getAttribute(\"style\").then(attribute => {vars[\"var1\"] = attribute;}));await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await driver.findElement(By.id(`test`)).then(element => {element.clear().then(() => {element.sendKeys(`${vars.var1}`);});});await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await expect(driver.findElement(By.id(`test`))).resolves.toHaveValue(`color: blue;`);}"
-    }, {
-      "name": "xpath count",
-      "code": "tests.xpath_count = async function xpath_count(driver, vars) {await driver.get(BASE_URL + \"/store/nodes.html\");await driver.wait(until.elementsLocated(By.xpath(`//span`)), configuration.timeout);await driver.findElements(By.xpath(`//span`)).then(elements => {vars[\"span_count\"] = elements.length;});await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await driver.findElement(By.id(`test`)).then(element => {element.clear().then(() => {element.sendKeys(`${vars.span_count}`);});});await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await expect(driver.findElement(By.id(`test`))).resolves.toHaveValue(`10`);await driver.wait(until.elementsLocated(By.xpath(`//div[contains(@class, \\\"testclass\\\")]`)), configuration.timeout);await driver.findElements(By.xpath(`//div[contains(@class, \\\"testclass\\\")]`)).then(elements => {vars[\"div_count\"] = elements.length;});await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await driver.findElement(By.id(`test`)).then(element => {element.clear().then(() => {element.sendKeys(`${vars.div_count}`);});});await driver.wait(until.elementLocated(By.id(`test`)), configuration.timeout);await expect(driver.findElement(By.id(`test`))).resolves.toHaveValue(`6`);}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }

--- a/tests/examples/text-comparison.side
+++ b/tests/examples/text-comparison.side
@@ -52,17 +52,5 @@
   }],
   "urls": ["https://en.wikipedia.org/", "http://localhost:5000/"],
   "plugins": [],
-  "version": "1.0",
-  "code": {
-    "suites": [{
-      "name": "text",
-      "persistSession": false,
-      "code": "global.BASE_URL = configuration.baseUrl || 'http://nginx:80';let vars = {};jest.setTimeout(300000);describe(\"text\", () => {it(\"text comparison\", async () => {await tests.text_comparison(driver, vars);await driver.getTitle().then(title => {expect(title).toBeDefined();});});});"
-    }],
-    "tests": [{
-      "name": "text comparison",
-      "code": "tests.text_comparison = async function text_comparison(driver, vars) {await driver.get(BASE_URL + \"/popup/alert.html\");await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await expect(driver.findElement(By.id(`b`))).resolves.toHaveText(`show alert`);await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await expect(driver.findElement(By.id(`b`))).resolves.toHaveText(`show alert`);await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {element.getText().then(text => {expect(text).not.toBe(`not show alert`)});});await driver.wait(until.elementLocated(By.id(`b`)), configuration.timeout);await driver.findElement(By.id(`b`)).then(element => {element.getText().then(text => {expect(text).not.toBe(`not show alert`)});});}"
-    }]
-  },
-  "dependencies": {}
+  "version": "1.0"
 }


### PR DESCRIPTION
Currently when saving a project using the betas, some code is appended to the file.  
This is because plugins has to be ran along side normal code that the runner needs.  
In order to reduce the amount of code in the file to the plugins alone (meaning those who do not use plugins will not feel the burden), a cache of plugin's code must be set, and used.

- [x] cache plugin's commands
- [x] cache plugin's test hooks
- [x] cache plugin's suite hooks
- [x] cache plugin's global hooks
- [x] rebuild the code tree in the runner using the snapshots
- [x] clean the project file from unnecessary properties
- [ ] publish [Selianize](https://github.com/SeleniumHQ/selenium-ide/tree/master/packages/selianize) to npm