### PR TITLE
remove the message which appears when I didn't anything.

### DIFF
--- a/packages/selenium-ide/src/neo/containers/Panel/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Panel/index.jsx
@@ -71,6 +71,7 @@ if (process.env.NODE_ENV === "production") {
 } else {
   seed(project, 0);
 }
+project.setModified(false);
 
 function firefox57WorkaroundForBlankPanel () {
   // TODO: remove this as soon as Mozilla fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1425829


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

I fixed #316, also I tested #256 too.