### PR TITLE
docs: add build:selianize before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ We are using [SideeX](http://sideex.org/) as a start point. The SideeX team was 
 ```peru sync```  
 ```yarn``` or if using Node 10 ```yarn --ignore-engines```
 - Build the extension  
+```yarn build:selianize``` and then
 ```yarn build:ext:prod``` or ```yarn build:ext``` for faster development build (also includes beta features)
 - Install as developer on [Google Chrome](https://developer.chrome.com/extensions/getstarted#unpacked) or [Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)  
 


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

---

Add `build:selianize`  before building script. If you did not run the script before, you would not build successfully because of an error below:

```
ERROR in ./api/v1/export.js
Module not found: Error: Can't resolve 'selianize' in '/Users/sotayamashita/Documents/src/selenium-ide/packages/selenium-ide/src/api/v1'
 @ ./api/v1/export.js 1:166-186
 @ ./api/v1/index.js
 @ ./api/index.js
 @ ./neo/containers/Panel/index.jsx
 @ ./neo/containers/Root/index.jsx
 @ multi react-hot-loader/patch ./neo/containers/Root

ERROR in ./neo/IO/filesystem.js
Module not found: Error: Can't resolve 'selianize' in '/Users/sotayamashita/Documents/src/selenium-ide/packages/selenium-ide/src/neo/IO'
 @ ./neo/IO/filesystem.js 1:958-978
 @ ./neo/containers/Panel/index.jsx
 @ ./neo/containers/Root/index.jsx
 @ multi react-hot-loader/patch ./neo/containers/Root

ERROR in ./plugin/manager.js
Module not found: Error: Can't resolve 'selianize' in '/Users/sotayamashita/Documents/src/selenium-ide/packages/selenium-ide/src/plugin'
 @ ./plugin/manager.js 17:15-35
 @ ./neo/IO/filesystem.js
 @ ./neo/containers/Panel/index.jsx
 @ ./neo/containers/Root/index.jsx
 @ multi react-hot-loader/patch ./neo/containers/Root
```