### PR TITLE
Add wildcard support to assertText with the existing PatternMatcher

### DIFF
--- a/packages/selenium-ide/src/content/selenium-api.js
+++ b/packages/selenium-ide/src/content/selenium-api.js
@@ -424,7 +424,7 @@ Selenium.prototype.findElementVisible = function(locator) {
 Selenium.prototype.doAssertText = function(locator, value) {
   const element = this.findElementVisible(locator);
   const visibleText = bot.dom.getVisibleText(element);
-  if (visibleText !== value) {
+  if (!PatternMatcher.matches(value, visibleText)) {
     throw new Error(`Actual value "${visibleText}" did not match "${value}"`);
   }
 };
@@ -432,7 +432,7 @@ Selenium.prototype.doAssertText = function(locator, value) {
 Selenium.prototype.doAssertNotText = function(locator, value) {
   const element = this.findElementVisible(locator);
   const visibleText = bot.dom.getVisibleText(element);
-  if (visibleText === value) {
+  if (PatternMatcher.matches(value, visibleText)) {
     throw new Error(`Actual value "${visibleText}" did match "${value}"`);
   }
 };

--- a/packages/selenium-ide/src/neo/IO/playback/webdriver.js
+++ b/packages/selenium-ide/src/neo/IO/playback/webdriver.js
@@ -20,6 +20,7 @@ import { absolutifyUrl } from "./utils";
 import variables from "../../stores/view/Variables";
 import { Logger, Channels } from "../../stores/view/Logs";
 import PlaybackState from "../../stores/view/PlaybackState";
+import PatternMatcher from "../../../content/PatternMatcher";
 
 const By = webdriver.By;
 const until = webdriver.until;
@@ -262,7 +263,7 @@ export default class WebDriverExecutor {
   async doAssertText(locator, value) {
     const element = await waitForElement(locator, this.driver);
     const text = await element.getText();
-    if (text !== value) {
+    if (!PatternMatcher.matches(value, text)) {
       throw new Error("Actual value '" + text + "' did not match '" + value + "'");
     }
   }
@@ -270,7 +271,7 @@ export default class WebDriverExecutor {
   async doAssertNotText(locator, value) {
     const element = await waitForElement(locator, this.driver);
     const text = await element.getText();
-    if (text === value) {
+    if (PatternMatcher.matches(value, text)) {
       throw new Error("Actual value '" + text + "' did match '" + value + "'");
     }
   }


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Fixes #141.

Add wildcard/regex support by reusing existing `PatternMatcher` implementation.

Open question - should this be enabled also for other checks than text/notText?