### PR TITLE
error fix when command starts with '//'

### DIFF
--- a/packages/selenium-ide/src/neo/playback/playback-tree/command-node.js
+++ b/packages/selenium-ide/src/neo/playback/playback-tree/command-node.js
@@ -103,7 +103,7 @@ export class CommandNode {
   }
 
   _executeCommand(commandExecutor, options, targetOverride) {
-    if (!Commands.list.get(this.command.command)) {
+    if (this.command.enabled && !Commands.list.get(this.command.command)) {
       throw new Error(`Unknown command ${this.command.command}`)
     } else if (this.isControlFlow()) {
       return this._evaluate(commandExecutor)


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)


After 6fe6af52eb257a154fd8bdf969cf5cccaafdecce commit, I can't execute disabled command.
Of course, the disabled command doesn't execute though, but an error occurs. 
Because when we check to validate of command, '//' was not considered.