### PR TITLE
Save last selected command per test to prevent the need to rescroll

### DIFF
--- a/packages/selenium-ide/src/neo/components/TestRow/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestRow/index.jsx
@@ -132,10 +132,11 @@ class TestRow extends React.Component {
     onContextMenu: PropTypes.func,
     setContextMenu: PropTypes.func,
     level: PropTypes.number,
+    scrollToLastPos: PropTypes.func,
   }
   componentDidMount() {
     if (this.props.selected) {
-      this.scrollToRowIfNeeded(this.node)
+      this.props.scrollToLastPos()
       this.props.setSectionFocus('editor', () => {
         this.node.focus()
       })

--- a/packages/selenium-ide/src/neo/components/TestRow/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestRow/index.jsx
@@ -135,6 +135,7 @@ class TestRow extends React.Component {
   }
   componentDidMount() {
     if (this.props.selected) {
+      this.scrollToRowIfNeeded(this.node)
       this.props.setSectionFocus('editor', () => {
         this.node.focus()
       })

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -34,11 +34,14 @@ export default class TestTable extends React.Component {
     this.newCommand = {}
     this.detectNewCommand = this.detectNewCommand.bind(this)
     this.disposeNewCommand = this.disposeNewCommand.bind(this)
+    this.handleScroll = this.handleScroll.bind(this)
+    this.scrollToLastPos = this.scrollToLastPos.bind(this)
     this.newObserverDisposer = observe(
       this.props.commands,
       this.detectNewCommand
     )
     this.commandLevels = []
+    this.node = null
   }
   static propTypes = {
     commands: MobxPropTypes.arrayOrObservableArray,
@@ -56,6 +59,13 @@ export default class TestTable extends React.Component {
   disposeNewCommand() {
     this.newCommand = undefined
   }
+  scrollToLastPos() {
+    if (UiState.selectedTest.state.scrollY) {
+      this.node.scrollTop = UiState.selectedTest.state.scrollY
+    } else {
+      this.node.scrollTop = 0
+    }
+  }
   componentDidUpdate(prevProps) {
     if (prevProps.commands !== this.props.commands) {
       this.newObserverDisposer()
@@ -66,6 +76,9 @@ export default class TestTable extends React.Component {
         )
       }
     }
+  }
+  handleScroll() {
+    UiState.selectedTest.state.scrollY = this.node.scrollTop
   }
   render() {
     if (this.props.commands)
@@ -89,6 +102,10 @@ export default class TestTable extends React.Component {
         </table>
       </div>,
       <div
+        onScroll={this.handleScroll}
+        ref={node => {
+          return (this.node = node || this.node)
+        }}
         key="body"
         className={classNames(
           'test-table',
@@ -125,6 +142,7 @@ export default class TestTable extends React.Component {
                           ? this.disposeNewCommand
                           : undefined
                       }
+                      scrollToLastPos={this.scrollToLastPos}
                       isPristine={false}
                       select={this.props.selectCommand}
                       startPlayingHere={PlaybackState.startPlaying}

--- a/packages/selenium-ide/src/neo/stores/view/TestState.js
+++ b/packages/selenium-ide/src/neo/stores/view/TestState.js
@@ -5,6 +5,8 @@ export default class SuiteState {
   modified = false
   @observable
   selectedCommand = null
+  @observable
+  scrollY = null
 
   constructor(test) {
     this.changeDisposer = reaction(

--- a/packages/selenium-ide/src/neo/stores/view/TestState.js
+++ b/packages/selenium-ide/src/neo/stores/view/TestState.js
@@ -3,6 +3,8 @@ import { reaction, observable } from 'mobx'
 export default class SuiteState {
   @observable
   modified = false
+  @observable
+  selectedCommand = null
 
   constructor(test) {
     this.changeDisposer = reaction(

--- a/packages/selenium-ide/src/neo/stores/view/UiState.js
+++ b/packages/selenium-ide/src/neo/stores/view/UiState.js
@@ -208,20 +208,23 @@ class UiState {
           ? PlaybackState.callstack[stack].callee
           : test
       if (_test !== this.displayedTest) {
+        this.selectedTest = {
+          test,
+          suite,
+          stack: stack >= 0 ? stack : undefined,
+          state: this.getTestState(test),
+        }
         if (PlaybackState.isPlaying && !PlaybackState.paused) {
           this.selectCommand(undefined)
         } else if (_test && _test.commands.length) {
-          this.selectCommand(_test.commands[0])
+          let command = this.selectedTest.state.selectedCommand
+          command = command ? command : _test.commands[0]
+          this.selectCommand(command)
         } else if (_test && !_test.commands.length) {
           this.selectCommand(this.pristineCommand)
         } else {
           this.selectCommand(undefined)
         }
-      }
-      this.selectedTest = {
-        test,
-        suite,
-        stack: stack >= 0 ? stack : undefined,
       }
     }
   }
@@ -299,6 +302,7 @@ class UiState {
       PlaybackState.paused ||
       opts.isCommandTarget
     ) {
+      this.selectedTest.state.selectedCommand = command
       this.selectedCommand = command
     }
   }


### PR DESCRIPTION
I added the field selectedCommand to the TestState which I set in selectCommand. When a new test is selected, I check to see if that field is set and use if set.

Test pass the same as in Master, Lints with no errors. 

For the proposed feature:
https://github.com/SeleniumHQ/selenium-ide/issues/510

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
