### PR TITLE
Fix to show alternative locators immediately, rather than having trigger a re-render  

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
@@ -100,8 +100,8 @@ export async function select(type, rect, selectNext = false) {
 function selectTarget(target) {
   UiState.setSelectingTarget(false)
   if (UiState.selectedCommand) {
-    UiState.selectedCommand.setTarget(target[0][0])
     UiState.selectedCommand.setTargets(target)
+    UiState.selectedCommand.setTarget(target[0][0])
   } else if (UiState.selectedTest.test) {
     const command = UiState.selectedTest.test.createCommand()
     command.setTargets(target)

--- a/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
@@ -104,8 +104,8 @@ function selectTarget(target) {
     UiState.selectedCommand.setTargets(target)
   } else if (UiState.selectedTest.test) {
     const command = UiState.selectedTest.test.createCommand()
-    command.setTarget(target[0][0])
     command.setTargets(target)
+    command.setTarget(target[0][0])
   }
 }
 


### PR DESCRIPTION
for: https://github.com/SeleniumHQ/selenium-ide/issues/503 
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
