### PR TITLE
Improvement of find button

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/find-select.js
@@ -22,6 +22,7 @@ import ModalState from '../../stores/view/ModalState'
 import WindowSession from '../../IO/window-session'
 import { TargetTypes } from '../../models/Command'
 import Region from '../../models/Region'
+import { xlateArgument } from './formatCommand'
 
 async function getActiveTabForTest() {
   const identifier = WindowSession.currentUsedWindowId[
@@ -39,20 +40,21 @@ async function getActiveTabForTest() {
 
 export async function find(target) {
   try {
+    const xlatedTarget = xlateArgument(target)
     const tab = await getActiveTabForTest()
-    const region = new Region(target)
+    const region = new Region(xlatedTarget)
     await browser.windows.update(tab.windowId, {
       focused: true,
     })
     try {
       await browser.tabs.sendMessage(tab.id, {
         showElement: true,
-        targetValue: region.isValid() ? region.toJS() : target,
+        targetValue: region.isValid() ? region.toJS() : xlatedTarget,
       })
     } catch (e) {
       ModalState.showAlert({
         title: 'Element not found',
-        description: `Could not find ${target} on the page`,
+        description: `Could not find ${xlatedTarget} on the page`,
         confirmLabel: 'Close',
       })
     }


### PR DESCRIPTION
In [test.zip](https://github.com/SeleniumHQ/selenium-ide/files/2726129/test.zip) case, if you click the find button, you can't find the element out.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/33743343/50675782-827b3580-1033-11e9-8524-4e1e9980d15d.gif)

I added `xlateArgument` before `sendMessage`.



- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
