### PR TITLE
changed from double keyDown to a keyDown and a keyUp for a KEY_ENTER

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
@@ -576,7 +576,7 @@ export default class ExtCommand {
           text: '\r',
         })
         await connection.sendCommand('Input.dispatchKeyEvent', {
-          type: 'keyDown',
+          type: 'keyUp',
           keyCode: 13,
           key: 'Enter',
           code: 'Enter',


### PR DESCRIPTION
- [ X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

When you call `sendKeys`, `sendCommand` is called `keyDown` twice.
It looks working well, but I think this was your intention.