### PR TITLE
Export Command module to library integrators

### DIFF
--- a/packages/selianize/src/index.js
+++ b/packages/selianize/src/index.js
@@ -137,6 +137,7 @@ export function ParseError(error) {
 }
 
 export const Location = LocationEmitter
+export const Command = CommandEmitter
 
 export function getUtilsFile() {
   return utils.getUtilsFile()


### PR DESCRIPTION
I am using Selianize to drive selenium but I would like to decouple my application from the 'side runners' assumptions about a project being a 'test' and use the commands in a more general way.

I ask that you merge this PR which is needed for me to call `Command.emit()` which is needed in my project.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)