### PR TITLE
add async and await keywords at deleteTest

### DIFF
--- a/packages/selenium-ide/src/neo/stores/view/ModalState.js
+++ b/packages/selenium-ide/src/neo/stores/view/ModalState.js
@@ -136,8 +136,8 @@ class ModalState {
   }
 
   @action.bound
-  deleteTest(testCase) {
-    const choseDelete = this.showAlert({
+  async deleteTest(testCase) {
+    const choseDelete = await this.showAlert({
       title: 'Delete test case',
       description: `This will permanently delete '${
         testCase.name


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

I think you missed `async` and `await` at deleteTest function.
So when you delete a test, whatever you choose `DELETE` or `CANCEL`, the test is already deleted.
Please check it.