### PR TITLE
checking isTerminal before executeCommand

### DIFF
--- a/packages/selenium-ide/src/neo/playback/playback-tree/command-node.js
+++ b/packages/selenium-ide/src/neo/playback/playback-tree/command-node.js
@@ -67,6 +67,11 @@ export class CommandNode {
           'Max retry limit exceeded. To override it, specify a new limit in the value input field.',
       })
     }
+    if (this.isTerminal()) {
+      return Promise.resolve(
+        this._executionResult(commandExecutor, { result: 'success' })
+      )
+    }
     return commandExecutor.beforeCommand(this.command).then(() => {
       return this._executeCommand(
         commandExecutor,
@@ -107,10 +112,6 @@ export class CommandNode {
       throw new Error(`Unknown command ${this.command.command}`)
     } else if (this.isControlFlow()) {
       return this._evaluate(commandExecutor)
-    } else if (this.isTerminal()) {
-      return Promise.resolve({
-        result: 'success',
-      })
     } else if (
       this.isWebDriverCommand(commandExecutor) ||
       this.isExtCommand(commandExecutor)


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

![gif](https://user-images.githubusercontent.com/33743343/53721308-43882580-3ea6-11e9-8b33-295c39ebc094.gif)

Test case : [selectWindow.txt](https://github.com/SeleniumHQ/selenium-ide/files/2924966/selectWindow.txt)

I found out some bug.
If I disable a command that be set `New Window configuration`, it returns an error.
Because of `afterCommand` method in `ext-command.js`.
The waitForNewWindow is set true by `beforeCommand` and it is executed `waitForNewWindowToAppear`.

But there is no new window because we disabled the command.
Then an error will occur.

So I changed a location of `isTerminal`.
If the command was disabled, not execute `beforeCommand` and `afterCommand`.
I think this is right.

