### PR TITLE
moved selectFrame command to brower side.

### DIFF
--- a/packages/selenium-ide/src/content/selenium-browserbot.js
+++ b/packages/selenium-ide/src/content/selenium-browserbot.js
@@ -1378,7 +1378,7 @@ BrowserBot.prototype.getNonTopWindowNames = function() {
 
 BrowserBot.prototype.getCurrentWindow = function(doNotModify) {
   if (this.proxyInjectionMode) {
-    return window
+    return this.currentWindow
   }
   let testWindow = core.firefox.unwrap(this.currentWindow)
   if (!doNotModify) {

--- a/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
@@ -869,7 +869,7 @@ export default class ExtCommand {
       case 'echo':
       case 'pause':
       case 'open':
-      case 'selectFrame':
+      // case 'selectFrame':
       case 'selectWindow':
       case 'run':
       case 'setWindowSize':

--- a/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/ext-command.js
@@ -869,7 +869,6 @@ export default class ExtCommand {
       case 'echo':
       case 'pause':
       case 'open':
-      // case 'selectFrame':
       case 'selectWindow':
       case 'run':
       case 'setWindowSize':


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

I tried to change a `selectFrame` command. 
Because I need to execute like old version. ( #537, #423)
If we do like this, we don't have to manage `tabId` anymore.
When I call a `selectFrame` command, `this.currentWindow` is set the frame that you selected.

Please try to check out this way.

test : [selectFrame.txt](https://github.com/SeleniumHQ/selenium-ide/files/2969948/selectFrame.txt)


