### PR TITLE
selenium-side-runner support multiple nested capabilities

### DIFF
--- a/packages/selenium-side-runner/src/__test__/capabilities.spec.js
+++ b/packages/selenium-side-runner/src/__test__/capabilities.spec.js
@@ -74,6 +74,20 @@ describe('capabilities string parser', () => {
       },
     })
   })
+  it('should parse multiple dot-notation capability key', () => {
+    const capabilities = `
+webdriver.remote.sessionid=someId
+webdriver.remote.username=username
+    `
+    expect(Capabilities.parseString(capabilities)).toEqual({
+      webdriver: {
+        remote: {
+          sessionid: 'someId',
+          username: 'username',
+        },
+      },
+    })
+  })
   it('should parse dot-notation arrays', () => {
     const capabilities = 'chromeOptions.args=[disable-infobars, headless]'
     expect(Capabilities.parseString(capabilities)).toEqual({

--- a/packages/selenium-side-runner/src/capabilities.js
+++ b/packages/selenium-side-runner/src/capabilities.js
@@ -19,7 +19,7 @@ export function parseString(input) {
   const capabilities = {}
 
   matchStringPairs(input).forEach(({ key, value }) => {
-    Object.assign(capabilities, assignStringKey(key, parseStringValue(value)))
+    assignStringKey(key, parseStringValue(value), capabilities)
   })
 
   return capabilities
@@ -30,7 +30,7 @@ export default {
 }
 
 function matchStringPairs(input) {
-  const regex = /([^ =]*) ?= ?(".*"|'.*'|\[.*\]|[^ ]*)/g
+  const regex = /([^\s=]*)\s?=\s?(".*"|'.*'|\[.*\]|[^\s]*)/g
   let result
   const splitCapabilities = []
   while ((result = regex.exec(input)) !== null) {
@@ -40,10 +40,14 @@ function matchStringPairs(input) {
   return splitCapabilities
 }
 
-function assignStringKey(key, value) {
-  const keyObject = {}
+function assignStringKey(key, value, keyObject) {
+  keyObject = keyObject || {}
+
   key.split('.').reduce((objectKey, currKey, index, keys) => {
-    const ref = {}
+    const ref =
+      !objectKey[currKey] || typeof objectKey[currKey] !== 'object'
+        ? {}
+        : objectKey[currKey]
     objectKey[currKey] = keys.length === index + 1 ? value : ref
     return ref
   }, keyObject)


### PR DESCRIPTION
For example:

```bash
selenium-side-runner -c "
  browserName='chrome'
  screener.name='My Chrome Test'
  screener.resolution='1280x1024'
  screener.apiKey='xxx'
  screener.group='xxx'
"
```

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
