### PR TITLE
feat: add --output-format=[jest | junit] to selenium-side-runner to export JUnit XML (V3)

### DIFF
--- a/docs/introduction/command-line-runner.md
+++ b/docs/introduction/command-line-runner.md
@@ -8,7 +8,7 @@ You can now run all of your Selenium IDE tests on any browser, in parallel, and 
 
 There's just the small matter of installing the Selenium IDE command line runner, getting the necessary browser drivers (if running your tests locally), and launching the runner from a command prompt with the options you want.
 
-![command-line-runner-sample](/selenium-ide/img/docs/runner.png)
+![command-line-runner-sample](/website/static/img/docs/runner.png)
 
 ## Prerequisites
 

--- a/docs/introduction/command-line-runner.md
+++ b/docs/introduction/command-line-runner.md
@@ -144,6 +144,34 @@ With Chrome specific capabilities you can also run the tests headlessly.
 selenium-side-runner -c "chromeOptions.args=[disable-infobars, headless]"
 ```
 
+### Output tests results to a file
+
+If you need to export test results to a file (when running as part of a CI process for example), you can use a combination `--output-directory` and `--output-format`.
+
+`--output-directory` defines if and where to put the test result files.
+
+`--output-format` defines which format use for the test result file, it can be `jest` or `junit`. The default if format is not specified is `jest`
+
+#### Examples
+
+```sh
+selenium-side-runner --output-directory=results
+```
+
+Will output results in `jest` frormat in `./results/projectName.json'
+
+```sh
+selenium-side-runner --output-directory=results --output-format=jest
+```
+
+Will output results in `jest` frormat in `./results/projectName.json'
+
+```sh
+selenium-side-runner --output-directory=results --output-format=junit
+```
+
+Will output results in `junit` frormat in `./results/projectName.xml'
+
 ## A framework at your fingertips
 
 There are also other niceties that come out of the box with the runner. Things you would expect to be available in a traditional test automation framework.

--- a/packages/selenium-side-runner/package.json
+++ b/packages/selenium-side-runner/package.json
@@ -34,6 +34,7 @@
     "global-npm": "^0.3.0",
     "jest-cli": "24.1.0",
     "jest-environment-selenium": "2.1.0",
+    "jest-junit": "^6.3.0",
     "js-beautify": "^1.7.5",
     "js-yaml": "^3.10.0",
     "rimraf": "^2.6.2",

--- a/packages/selenium-side-runner/src/index.js
+++ b/packages/selenium-side-runner/src/index.js
@@ -252,7 +252,7 @@ function runProject(project) {
     return Promise.reject(
       new Error(
         `The project ${
-        project.name
+          project.name
         } has no test suites defined, create a suite using the IDE.`
       )
     )
@@ -305,7 +305,7 @@ function runProject(project) {
           writeJSFile(
             path.join(projectPath, sanitizeFileName(suite.name)),
             `// This file was generated using Selenium IDE\nconst tests = require("./commons.js");${
-            code.globalConfig
+              code.globalConfig
             }${suite.code}${cleanup}`
           )
         } else if (suite.tests.length) {
@@ -319,7 +319,7 @@ function runProject(project) {
                 sanitizeFileName(test.name)
               ),
               `// This file was generated using Selenium IDE\nconst tests = require("../commons.js");${
-              code.globalConfig
+                code.globalConfig
               }${test.code}`
             )
           })

--- a/packages/selenium-side-runner/src/index.js
+++ b/packages/selenium-side-runner/src/index.js
@@ -73,6 +73,10 @@ program
     'Write test results to files, results written in JSON'
   )
   .option(
+    '--junit',
+    'Write test results to files, results written in JUnit XML format'
+  )
+  .option(
     '--force',
     "Forcibly run the project, regardless of project's version"
   )
@@ -228,7 +232,18 @@ function runProject(project) {
           ],
           testEnvironment: 'jest-environment-selenium',
           testEnvironmentOptions: configuration,
+          ...(program.junit ? { reporters: ['default', 'jest-junit'] } : {}),
         },
+        ...(program.junit && program.outputDirectory
+          ? {
+              'jest-junit': {
+                outputDirectory: path.isAbsolute(program.outputDirectory)
+                  ? program.outputDirectory
+                  : '../' + program.outputDirectory,
+                outputName: `${project.name}.xml`,
+              },
+            }
+          : {}),
         dependencies: project.dependencies || {},
       },
       null,
@@ -319,7 +334,7 @@ function runJest(project) {
     ]
       .concat(program.maxWorkers ? ['-w', program.maxWorkers] : [])
       .concat(
-        program.outputDirectory
+        program.outputDirectory && !program.junit
           ? [
               '--json',
               '--outputFile',


### PR DESCRIPTION
Same as #659 but for  v3

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
