### PR TITLE
extension-boilerplate is on v3 branch

### DIFF
--- a/docs/plugins/getting-started.md
+++ b/docs/plugins/getting-started.md
@@ -6,7 +6,7 @@ sidebar_label: Getting Started
 
 Plugins can extend Selenium IDE's default behavior, through adding additional commands and locators, bootstrapping setup before and after test runs, and affecting the recording process.  
 
-Selenium IDE is using the WebExtension standard to work in modern browsers (to learn more, you can check out Mozilla's <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_first_WebExtension" target="_blank" rel="noopener noreferrer">Your first extension</a> article). Communicating between the extensions is handled via the <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/sendMessage" target="_blank" rel="noopener noreferrer">external messaging protocol</a>, you can view an example of that <a href="https://github.com/SeleniumHQ/selenium-ide/tree/master/packages/extension-boilerplate" target="_blank" rel="noopener noreferrer">here</a>.  
+Selenium IDE is using the WebExtension standard to work in modern browsers (to learn more, you can check out Mozilla's <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_first_WebExtension" target="_blank" rel="noopener noreferrer">Your first extension</a> article). Communicating between the extensions is handled via the <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/sendMessage" target="_blank" rel="noopener noreferrer">external messaging protocol</a>, you can view an example of that <a href="https://github.com/SeleniumHQ/selenium-ide/tree/v3/packages/extension-boilerplate" target="_blank" rel="noopener noreferrer">here</a>.  
 
 This article assumes knowledge in WebExtension development, and will only discuss Selenium IDE specific capabilities.
 


### PR DESCRIPTION
Hello,
I started reading documentation here https://www.seleniumhq.org/selenium-ide/docs/en/plugins/plugins-getting-started/ and hit a link pointing to non-existing place.
I found out that boilerplate is on `v3` branch.

For the time being it might be useful to point that branch until browsers' extensions get deprecated.

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
