### PR TITLE
Fixed to navigate issue when argument text link contains spaces

### DIFF
--- a/packages/selenium-ide/src/neo/components/CommandReference/index.js
+++ b/packages/selenium-ide/src/neo/components/CommandReference/index.js
@@ -36,7 +36,7 @@ export default class CommandReference extends React.Component {
   }
   linkForArgument(param) {
     return `https://www.seleniumhq.org/selenium-ide/docs/en/api/arguments/#${param.name
-      .replace(/ /g, '-')
+      .replace(/ /g, '')
       .toLowerCase()}`
   }
   argument(param) {


### PR DESCRIPTION
Fixed an issue where focusing could not be done when clicking argument text link contains spaces

AS-IS
![image](https://user-images.githubusercontent.com/31546782/57284152-90c58500-70eb-11e9-8096-7308e958b047.png)

TO-BE
![image](https://user-images.githubusercontent.com/31546782/57284267-c9fdf500-70eb-11e9-8a32-5b6c046f36b3.png)

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
