### PR TITLE
Added set default value when select 'wait for...' command

### DIFF
--- a/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
@@ -207,17 +207,18 @@ describe('Command', () => {
     expect(command instanceof Command).toBeTruthy()
   })
 
-  it('should set default value in the wait for command when there is no value', () => {
+  it('should not overridden value when replace command', () => {
     const command = new Command()
+    command.setCommand('assert text')
+    command.setValue('Hello World')
     command.setCommand('wait for element present')
-    expect(command.value).toBe('30000')
+    expect(command.value).toBe('Hello World')
   })
 
-  it('should set value in the wait for command when there is a value', () => {
+  it("should not set value for commands that do not start with 'wait for'", () => {
     const command = new Command()
-    command.setCommand('wait for element editable')
-    command.setValue('50000')
-    expect(command.value).toBe('50000')
+    command.setCommand('click')
+    expect(command.value).toBe('')
   })
 })
 

--- a/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
+++ b/packages/selenium-ide/src/neo/__test__/models/Command.spec.js
@@ -206,6 +206,19 @@ describe('Command', () => {
     expect(command.windowTimeout).toBe(jsRepresentation.windowTimeout)
     expect(command instanceof Command).toBeTruthy()
   })
+
+  it('should set default value in the wait for command when there is no value', () => {
+    const command = new Command()
+    command.setCommand('wait for element present')
+    expect(command.value).toBe('30000')
+  })
+
+  it('should set value in the wait for command when there is a value', () => {
+    const command = new Command()
+    command.setCommand('wait for element editable')
+    command.setValue('50000')
+    expect(command.value).toBe('50000')
+  })
 })
 
 describe('Commands enum', () => {

--- a/packages/selenium-ide/src/neo/models/Command/index.js
+++ b/packages/selenium-ide/src/neo/models/Command/index.js
@@ -107,7 +107,7 @@ export default class Command {
       this.setTargets()
     }
 
-    if (this.command.indexOf('waitFor') > -1) {
+    if (this.command.indexOf('waitFor') > -1 && this.value === '') {
       this.setValue('30000')
     }
   }

--- a/packages/selenium-ide/src/neo/models/Command/index.js
+++ b/packages/selenium-ide/src/neo/models/Command/index.js
@@ -106,6 +106,10 @@ export default class Command {
     if (!this.canHaveTargets) {
       this.setTargets()
     }
+
+    if (this.command.indexOf('waitFor') > -1) {
+      this.setValue('30000')
+    }
   }
 
   @action.bound


### PR DESCRIPTION
Set the default value 3000 (30 seconds) when select 'wait for...' command.
![image](https://user-images.githubusercontent.com/31546782/57377211-d910a000-71dc-11e9-9f0a-80c92ee4f9cd.png)

Related issue #618

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
