### PR TITLE
 Added timestamp against each log

### DIFF
--- a/packages/selenium-ide/src/neo/components/LogMessage/index.jsx
+++ b/packages/selenium-ide/src/neo/components/LogMessage/index.jsx
@@ -37,6 +37,12 @@ export default class LogMessage extends React.Component {
         statusMessage = 'Undetermined'
       }
     }
+
+    let hours = ("0" + this.props.log.timestamp.getHours()).slice(-2)
+    let minutes = ("0" + this.props.log.timestamp.getMinutes()).slice(-2)
+    let seconds = ("0" + this.props.log.timestamp.getSeconds()).slice(-2)
+    let time = hours + ":" + minutes + ":" + seconds
+
     return (
       <li
         className={classNames('log', this.props.log.status, {
@@ -49,7 +55,7 @@ export default class LogMessage extends React.Component {
           }}
         >
           <div className="log-overview">
-            <span className="time">[{this.props.log.time}]</span>
+            <span className="time">[{time}]</span>
             {this.props.log.index && (
               <span className="index">{this.props.log.index}.</span>
             )}

--- a/packages/selenium-ide/src/neo/components/LogMessage/index.jsx
+++ b/packages/selenium-ide/src/neo/components/LogMessage/index.jsx
@@ -49,6 +49,7 @@ export default class LogMessage extends React.Component {
           }}
         >
           <div className="log-overview">
+            <span className="time">[{this.props.log.time}]</span>
             {this.props.log.index && (
               <span className="index">{this.props.log.index}.</span>
             )}

--- a/packages/selenium-ide/src/neo/components/LogMessage/style.css
+++ b/packages/selenium-ide/src/neo/components/LogMessage/style.css
@@ -7,6 +7,10 @@
   width: 20px;
 }
 
+.log .time {
+  padding-right: 5px;
+}
+
 .log.notice {
   font-weight: bold;
 }

--- a/packages/selenium-ide/src/neo/ui-models/Log.js
+++ b/packages/selenium-ide/src/neo/ui-models/Log.js
@@ -20,6 +20,7 @@ import uuidv4 from 'uuid/v4'
 
 export default class Log {
   id = uuidv4()
+  timestamp = null
   @observable
   index = null
   @observable
@@ -34,13 +35,11 @@ export default class Log {
   channel = null
   @observable
   isNotice = false
-  @observable
-  time = false
 
   constructor(message, status) {
     this.message = message
     this.status = status
-    this.setTime()
+    this.timestamp = new Date()
   }
 
   @action.bound

--- a/packages/selenium-ide/src/neo/ui-models/Log.js
+++ b/packages/selenium-ide/src/neo/ui-models/Log.js
@@ -34,10 +34,13 @@ export default class Log {
   channel = null
   @observable
   isNotice = false
+  @observable
+  time = false
 
   constructor(message, status) {
     this.message = message
     this.status = status
+    this.setTime()
   }
 
   @action.bound
@@ -73,6 +76,11 @@ export default class Log {
   @action.bound
   setNotice() {
     this.isNotice = true
+  }
+
+  @action.bound
+  setTime() {
+    this.time = new Date().toLocaleString().trim()
   }
 
   @action.bound


### PR DESCRIPTION
This is an implementation to provide timestamp to client selenium ide log.
'toLocaleString ()' returns the year, month, and day of the month in a time format appropriate to each culture.

![include_timestamp_log](https://user-images.githubusercontent.com/31546782/57751571-2a5ee900-7721-11e9-87d1-6351086e9bd4.png)

Related issue #552

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
