### PR TITLE
Remove chromedriver start logic

### DIFF
--- a/packages/selenium-ide/src/index.js
+++ b/packages/selenium-ide/src/index.js
@@ -1,6 +1,5 @@
 const { app, BrowserWindow } = require('electron')
 const webdriver = require('selenium-webdriver')
-const chromedriver = require('chromedriver')
 
 app.commandLine.appendSwitch('remote-debugging-port', '8315')
 
@@ -14,9 +13,7 @@ app.on('ready', async () => {
 
   // and load the index.html of the app.
   win.loadFile(__dirname + '/index.html')
-
-  chromedriver.start()
-
+  
   const driver = new webdriver.Builder()
     // The "9515" is the port opened by chrome driver.
     .usingServer('http://localhost:9515')


### PR DESCRIPTION
The chromedriver must be run separately.

I am interested in participating in the development of Selenium Electron app.
I ran the app and I am getting the following error.
```
A JavaScript error occurred in the main process

Uncaught Exception:
Error: Cannot find module 'chromedriver'
```

Please refer to the [link](https://electronjs.org/docs/tutorial/using-selenium-and-webdriver#1-start-chromedriver).


<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
