### PR TITLE
Issue #263 Chrome Extension stuck in infinite loop on site

### DIFF
--- a/packages/side-recorder/src/content/prompt.js
+++ b/packages/side-recorder/src/content/prompt.js
@@ -85,8 +85,9 @@ window.__side.getFrameLocation = () => {
   let currentParentWindow
   while (currentWindow !== window.top) {
     currentParentWindow = currentWindow.parent
-    for (let idx = 0; idx < currentParentWindow.frames.length; idx++)
-      if (currentParentWindow.frames[idx] === currentWindow) {
+    let frames = currentParentWindow.document.getElementsByTagName('IFRAME');
+    for (let idx = 0; idx < frames.length; idx++)
+      if (frames[idx].contentWindow === currentWindow) {
         frameLocation = ':' + idx + frameLocation
         currentWindow = currentParentWindow
         break

--- a/packages/side-recorder/src/content/prompt.js
+++ b/packages/side-recorder/src/content/prompt.js
@@ -85,7 +85,7 @@ window.__side.getFrameLocation = () => {
   let currentParentWindow
   while (currentWindow !== window.top) {
     currentParentWindow = currentWindow.parent
-    let frames = currentParentWindow.document.getElementsByTagName('IFRAME');
+    let frames = currentParentWindow.document.getElementsByTagName('IFRAME')
     for (let idx = 0; idx < frames.length; idx++)
       if (frames[idx].contentWindow === currentWindow) {
         frameLocation = ':' + idx + frameLocation

--- a/packages/side-recorder/src/content/recorder.js
+++ b/packages/side-recorder/src/content/recorder.js
@@ -226,7 +226,7 @@ export default class Recorder {
 
   addRecordingIndicator() {
     if (this.frameLocation === 'root' && !this.recordingIndicator) {
-      const indicatorIndex = this.window.parent.frames.length
+      const indicatorIndex = this.window.parent.document.getElementsByTagName('IFRAME').length
       this.recordingIndicator = this.window.document.createElement('iframe')
       this.recordingIndicator.src = browser.runtime.getURL('/indicator.html')
       this.recordingIndicator.id = 'selenium-ide-indicator'
@@ -299,7 +299,8 @@ export default class Recorder {
 
     while (currentWindow !== this.window.top) {
       currentParentWindow = currentWindow.parent
-      if (!currentParentWindow.frames.length) {
+      let frames = currentParentWindow.document.getElementsByTagName('IFRAME')
+      if (!frames.length) {
         break
       }
 
@@ -308,10 +309,8 @@ export default class Recorder {
         if (frameCount) recordingIndicatorIndex = frameCount.indicatorIndex
       }
 
-      for (let idx = 0; idx < currentParentWindow.frames.length; idx++) {
-        const frame = currentParentWindow.frames[idx]
-
-        if (frame === currentWindow) {
+      for (let idx = 0; idx < frames.length; idx++) {
+        if (frames[idx].contentWindow === currentWindow) {
           this.frameLocation =
             ':' +
             calculateFrameIndex({

--- a/packages/side-recorder/src/content/recorder.js
+++ b/packages/side-recorder/src/content/recorder.js
@@ -226,7 +226,9 @@ export default class Recorder {
 
   addRecordingIndicator() {
     if (this.frameLocation === 'root' && !this.recordingIndicator) {
-      const indicatorIndex = this.window.parent.document.getElementsByTagName('IFRAME').length
+      const indicatorIndex = this.window.parent.document.getElementsByTagName(
+        'IFRAME'
+      ).length
       this.recordingIndicator = this.window.document.createElement('iframe')
       this.recordingIndicator.src = browser.runtime.getURL('/indicator.html')
       this.recordingIndicator.id = 'selenium-ide-indicator'


### PR DESCRIPTION
window.parent.frames does not include iframes added dynamically, causing an infinite loop - so use getElementsByTagName instead

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
