### PR TITLE
Fixed typo. Action reference should be Actions reference to avoid casting.

### DIFF
--- a/packages/code-export-java-junit/__test__/src/__snapshots__/command.spec.js.snap
+++ b/packages/code-export-java-junit/__test__/src/__snapshots__/command.spec.js.snap
@@ -212,7 +212,7 @@ Object {
 exports[`command code emitter should emit \`mouse down at\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).clickAndHold().perform();
 }"
 `;
@@ -220,7 +220,7 @@ exports[`command code emitter should emit \`mouse down at\` event 1`] = `
 exports[`command code emitter should emit \`mouse down\` command 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).clickAndHold().perform();
 }"
 `;
@@ -228,7 +228,7 @@ exports[`command code emitter should emit \`mouse down\` command 1`] = `
 exports[`command code emitter should emit \`mouse move at\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).perform();
 }"
 `;
@@ -236,7 +236,7 @@ exports[`command code emitter should emit \`mouse move at\` event 1`] = `
 exports[`command code emitter should emit \`mouse move\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).perform();
 }"
 `;
@@ -244,7 +244,7 @@ exports[`command code emitter should emit \`mouse move\` event 1`] = `
 exports[`command code emitter should emit \`mouse out\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.tagName(\\"body\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element, 0, 0).perform();
 }"
 `;
@@ -252,7 +252,7 @@ exports[`command code emitter should emit \`mouse out\` event 1`] = `
 exports[`command code emitter should emit \`mouse over\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).perform();
 }"
 `;
@@ -260,7 +260,7 @@ exports[`command code emitter should emit \`mouse over\` event 1`] = `
 exports[`command code emitter should emit \`mouse up at\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).release().perform();
 }"
 `;
@@ -268,7 +268,7 @@ exports[`command code emitter should emit \`mouse up at\` event 1`] = `
 exports[`command code emitter should emit \`mouse up\` event 1`] = `
 "{
   WebElement element = driver.findElement(By.id(\\"button\\"));
-  Action builder = new Actions(driver);
+  Actions builder = new Actions(driver);
   builder.moveToElement(element).release().perform();
 }"
 `;

--- a/packages/code-export-java-junit/src/command.js
+++ b/packages/code-export-java-junit/src/command.js
@@ -425,7 +425,7 @@ async function emitMouseDown(locator) {
         locator
       )});`,
     },
-    { level: 1, statement: 'Action builder = new Actions(driver);' },
+    { level: 1, statement: 'Actions builder = new Actions(driver);' },
     {
       level: 1,
       statement: 'builder.moveToElement(element).clickAndHold().perform();',
@@ -444,7 +444,7 @@ async function emitMouseMove(locator) {
         locator
       )});`,
     },
-    { level: 1, statement: 'Action builder = new Actions(driver);' },
+    { level: 1, statement: 'Actions builder = new Actions(driver);' },
     { level: 1, statement: 'builder.moveToElement(element).perform();' },
     { level: 0, statement: '}' },
   ]
@@ -458,7 +458,7 @@ async function emitMouseOut() {
       level: 1,
       statement: `WebElement element = driver.findElement(By.tagName("body"));`,
     },
-    { level: 1, statement: 'Action builder = new Actions(driver);' },
+    { level: 1, statement: 'Actions builder = new Actions(driver);' },
     { level: 1, statement: 'builder.moveToElement(element, 0, 0).perform();' },
     { level: 0, statement: '}' },
   ]
@@ -474,7 +474,7 @@ async function emitMouseUp(locator) {
         locator
       )});`,
     },
-    { level: 1, statement: 'Action builder = new Actions(driver);' },
+    { level: 1, statement: 'Actions builder = new Actions(driver);' },
     {
       level: 1,
       statement: 'builder.moveToElement(element).release().perform();',


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
The `emitMouseDown`, `emitMouseMove`, `emitMouseOut`, `emitMouseUp` functions for any mouse specific commands generates the below line when performing Java JUnit code export:

`Action builder = new Actions(driver);`

This does not work out of the box and requires additional import and casting. To avoid this use `Actions` reference:

`Actions builder = new Actions(driver);`

This has already been implemented for other commands Eg: `emitDoubleClick`, `emitDragAndDrop`..etc. Hence this pull request is possibly a typo fix.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
