### PR TITLE
Fixed typo in code-export.md

### DIFF
--- a/docs/introduction/code-export.md
+++ b/docs/introduction/code-export.md
@@ -11,7 +11,7 @@ You can export either a test or suite of tests to WebDriver code by right-clicki
 ![code-export-right-click](/selenium-ide/img/docs/code-export/right-click.png)
 ![code-export-menu](/selenium-ide/img/docs/code-export/menu.png)
 
-This will save a file containing the exported code for your targret language to your browser's download directory.
+This will save a file containing the exported code for your target language to your browser's download directory.
 
 ### Origin Tracing Code Comments
 


### PR DESCRIPTION
Typo found and fixed in code-export.md file. 
Word was targret and now target

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
