### PR TITLE
Updated Python code export command emitters that use ActionChains to …

### DIFF
--- a/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
+++ b/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
@@ -282,7 +282,7 @@ exports[`command code emitter should emit \`store xpath count\` command 1`] = `"
 
 exports[`command code emitter should emit \`store\` command 1`] = `"self.vars[\\"myVar\\"] = \\"some value\\""`;
 
-exports[`command code emitter should emit \`submit\` command 1`] = `"raise Exception(\\"\`submit\` is not a supported command in Selenium Webself.driver. Please re-record the step in the IDE.\\")"`;
+exports[`command code emitter should emit \`submit\` command 1`] = `"raise Exception(\\"'submit' is not a supported command in Selenium WebDriver. Please re-record the step in the IDE.\\")"`;
 
 exports[`command code emitter should emit \`times\` command 1`] = `
 Object {

--- a/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
+++ b/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
@@ -106,20 +106,20 @@ while condition:",
 
 exports[`command code emitter should emit \`double click at\` command 1`] = `
 "element = self.driver.find_element(By.LINK_TEXT, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.double_click(element).perform()"
 `;
 
 exports[`command code emitter should emit \`double click\` command 1`] = `
 "element = self.driver.find_element(By.LINK_TEXT, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.double_click(element).perform()"
 `;
 
 exports[`command code emitter should emit \`drag and drop to object\` command 1`] = `
 "dragged = self.driver.find_element(By.LINK_TEXT, \\"dragged\\")
 dropped = self.driver.find_element(By.LINK_TEXT, \\"dropped\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.drag_and_drop(dragged, dropped).perform()"
 `;
 
@@ -177,49 +177,49 @@ Object {
 
 exports[`command code emitter should emit \`mouse down at\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).click_and_hold().perform()"
 `;
 
 exports[`command code emitter should emit \`mouse down\` command 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).click_and_hold().perform()"
 `;
 
 exports[`command code emitter should emit \`mouse move at\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).perform()"
 `;
 
 exports[`command code emitter should emit \`mouse move\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).perform()"
 `;
 
 exports[`command code emitter should emit \`mouse out\` event 1`] = `
 "element = self.driver.find_element(By.CSS_SELECTOR, \\"body\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element, 0, 0).perform()"
 `;
 
 exports[`command code emitter should emit \`mouse over\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).perform()"
 `;
 
 exports[`command code emitter should emit \`mouse up at\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).release().perform()"
 `;
 
 exports[`command code emitter should emit \`mouse up\` event 1`] = `
 "element = self.driver.find_element(By.ID, \\"button\\")
-actions = ActionChains(driver)
+actions = ActionChains(self.driver)
 actions.move_to_element(element).release().perform()"
 `;
 

--- a/packages/code-export-python-pytest/src/command.js
+++ b/packages/code-export-python-pytest/src/command.js
@@ -679,7 +679,7 @@ async function emitStoreXpathCount(locator, varName) {
 
 async function emitSubmit(_locator) {
   return Promise.resolve(
-    `raise Exception("\`submit\` is not a supported command in Selenium Webself.driver. Please re-record the step in the IDE.")`
+    `raise Exception("'submit' is not a supported command in Selenium WebDriver. Please re-record the step in the IDE.")`
   )
 }
 

--- a/packages/code-export-python-pytest/src/command.js
+++ b/packages/code-export-python-pytest/src/command.js
@@ -351,7 +351,7 @@ async function emitDoubleClick(target) {
         target
       )})`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     { level: 0, statement: 'actions.double_click(element).perform()' },
   ]
   return Promise.resolve({ commands })
@@ -371,7 +371,7 @@ async function emitDragAndDrop(dragged, dropped) {
         dropped
       )})`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     {
       level: 0,
       statement: 'actions.drag_and_drop(dragged, dropped).perform()',
@@ -424,7 +424,7 @@ async function emitMouseDown(locator) {
         locator
       )})`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     {
       level: 0,
       statement: 'actions.move_to_element(element).click_and_hold().perform()',
@@ -441,7 +441,7 @@ async function emitMouseMove(locator) {
         locator
       )})`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     { level: 0, statement: 'actions.move_to_element(element).perform()' },
   ]
   return Promise.resolve({ commands })
@@ -453,7 +453,7 @@ async function emitMouseOut() {
       level: 0,
       statement: `element = self.driver.find_element(By.CSS_SELECTOR, "body")`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     { level: 0, statement: 'actions.move_to_element(element, 0, 0).perform()' },
   ]
   return Promise.resolve({ commands })
@@ -467,7 +467,7 @@ async function emitMouseUp(locator) {
         locator
       )})`,
     },
-    { level: 0, statement: 'actions = ActionChains(driver)' },
+    { level: 0, statement: 'actions = ActionChains(self.driver)' },
     {
       level: 0,
       statement: 'actions.move_to_element(element).release().perform()',


### PR DESCRIPTION
…use argument self.driver

Was using just driver which resulted in NameError exception when executing the exported code.
Fix for issue https://github.com/SeleniumHQ/selenium-ide/issues/826

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
