### PR TITLE
867 Add all commands to context menu

### DIFF
--- a/packages/selenium-ide/src/content/record.js
+++ b/packages/selenium-ide/src/content/record.js
@@ -644,10 +644,18 @@ Recorder.addEventHandler(
         let tmpText = bot.dom.getVisibleText(event.target)
         record(m.cmd, tmpTarget, tmpText)
       } else if (m.cmd.includes('Title')) {
-        let tmpTitle = goog.string.normalizeSpaces(event.target.ownerDocument.title)
+        let tmpTitle = goog.string.normalizeSpaces(
+          event.target.ownerDocument.title
+        )
         record(m.cmd, [[tmpTitle]], '')
-      } else if (m.cmd.includes('Present') || m.cmd.includes('Checked') || m.cmd.includes('Editable')
-          || m.cmd.includes('Selected') || m.cmd.includes('Visible') || m.cmd === 'mouseOver') {
+      } else if (
+        m.cmd.includes('Present') ||
+        m.cmd.includes('Checked') ||
+        m.cmd.includes('Editable') ||
+        m.cmd.includes('Selected') ||
+        m.cmd.includes('Visible') ||
+        m.cmd === 'mouseOver'
+      ) {
         record(m.cmd, tmpTarget, '')
       } else if (m.cmd.includes('Value')) {
         let tmpValue = event.target.value

--- a/packages/selenium-ide/src/content/record.js
+++ b/packages/selenium-ide/src/content/record.js
@@ -638,18 +638,20 @@ Recorder.addEventHandler(
   'contextmenu',
   function(event) {
     let myPort = browser.runtime.connect()
-    let tmpText = locatorBuilders.buildAll(event.target)
-    let tmpVal = bot.dom.getVisibleText(event.target)
-    let tmpTitle = goog.string.normalizeSpaces(event.target.ownerDocument.title)
+    let tmpTarget = locatorBuilders.buildAll(event.target)
     myPort.onMessage.addListener(function(m) {
-      if (m.cmd.includes('Text')) {
-        record(m.cmd, tmpText, tmpVal)
+      if (m.cmd.includes('Text') || m.cmd.includes('Label')) {
+        let tmpText = bot.dom.getVisibleText(event.target)
+        record(m.cmd, tmpTarget, tmpText)
       } else if (m.cmd.includes('Title')) {
+        let tmpTitle = goog.string.normalizeSpaces(event.target.ownerDocument.title)
         record(m.cmd, [[tmpTitle]], '')
+      } else if (m.cmd.includes('Present') || m.cmd.includes('Checked') || m.cmd.includes('Editable')
+          || m.cmd.includes('Selected') || m.cmd.includes('Visible') || m.cmd === 'mouseOver') {
+        record(m.cmd, tmpTarget, '')
       } else if (m.cmd.includes('Value')) {
-        record(m.cmd, tmpText, event.target.value)
-      } else if (m.cmd === 'mouseOver') {
-        record('mouseOver', locatorBuilders.buildAll(event.target), '')
+        let tmpValue = event.target.value
+        record(m.cmd, tmpTarget, tmpValue)
       }
       myPort.onMessage.removeListener(this)
     })

--- a/packages/selenium-ide/src/neo/IO/SideeX/recorder.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/recorder.js
@@ -381,12 +381,12 @@ export default class BackgroundRecorder {
       typeof message.value === 'undefined'
     ) {
       logger.error(
-        "This element does not have property 'value'. Please change to use storeText command."
+        "This element does not have property 'Value'. Please change to use a 'Text' command instead."
       )
       return
     } else if (message.command.includes('Text') && message.value === '') {
       logger.error(
-        "This element does not have property 'Text'. Please change to use storeValue command."
+        "This element does not have property 'Text'. Please change to use a 'Value' command instead."
       )
       return
     } else if (message.command.includes('store')) {

--- a/packages/selenium-ide/src/neo/side-effects/contextMenu.js
+++ b/packages/selenium-ide/src/neo/side-effects/contextMenu.js
@@ -22,40 +22,273 @@ function createContextMenus() {
     contexts: ['all'],
   })
   browser.contextMenus.create({
-    id: 'verifyText',
-    title: 'Verify Text',
+    id: 'assert',
+    title: 'Assert',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
   })
   browser.contextMenus.create({
-    id: 'verifyTitle',
-    title: 'Verify Title',
+    id: 'assertChecked',
+    title: 'Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertEditable',
+    title: 'Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertNotChecked',
+    title: 'Not Checked',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertNotEditable',
+    title: 'Not Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertElementNotPresent',
+    title: 'Not Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertNotSelectedValue',
+    title: 'Not Selected Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertNotText',
+    title: 'Not Text',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertElementPresent',
+    title: 'Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertSelectedLabel',
+    title: 'Selected Label',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'assertSelectedValue',
+    title: 'Selected Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
   })
   browser.contextMenus.create({
     id: 'assertText',
-    title: 'Assert Text',
+    title: 'Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
+    parentId: 'assert'
   })
   browser.contextMenus.create({
     id: 'assertTitle',
-    title: 'Assert Title',
+    title: 'Title',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+   browser.contextMenus.create({
+    id: 'assertValue',
+    title: 'Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'assert'
+  })
+  browser.contextMenus.create({
+    id: 'store',
+    title: 'Store',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
   })
   browser.contextMenus.create({
     id: 'storeText',
-    title: 'Store Text',
+    title: 'Text',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'store'
+  })
+  browser.contextMenus.create({
+    id: 'storeTitle',
+    title: 'Title',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'store'
+  })
+   browser.contextMenus.create({
+    id: 'storeValue',
+    title: 'Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'store'
+  })
+  browser.contextMenus.create({
+    id: 'verify',
+    title: 'Verify',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
   })
   browser.contextMenus.create({
-    id: 'storeTitle',
-    title: 'Store Title',
+    id: 'verifyChecked',
+    title: 'Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyEditable',
+    title: 'Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyNotChecked',
+    title: 'Not Checked',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyNotEditable',
+    title: 'Not Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyElementNotPresent',
+    title: 'Not Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyNotSelectedValue',
+    title: 'Not Selected Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyNotText',
+    title: 'Not Text',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyElementPresent',
+    title: 'Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifySelectedLabel',
+    title: 'Selected Label',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifySelectedValue',
+    title: 'Selected Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyText',
+    title: 'Text',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'verifyTitle',
+    title: 'Title',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+   browser.contextMenus.create({
+    id: 'verifyValue',
+    title: 'Value',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'verify'
+  })
+  browser.contextMenus.create({
+    id: 'waitFor',
+    title: 'Wait For',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementEditable',
+    title: 'Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementNotEditable',
+    title: 'Not Editable',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementNotPresent',
+    title: 'Not Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementNotVisible',
+    title: 'Not Visible',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementPresent',
+    title: 'Present',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
+  })
+  browser.contextMenus.create({
+    id: 'waitForElementVisible',
+    title: 'Visible',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor'
   })
 }
 

--- a/packages/selenium-ide/src/neo/side-effects/contextMenu.js
+++ b/packages/selenium-ide/src/neo/side-effects/contextMenu.js
@@ -32,91 +32,91 @@ function createContextMenus() {
     title: 'Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertEditable',
     title: 'Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertNotChecked',
     title: 'Not Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertNotEditable',
     title: 'Not Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertElementNotPresent',
     title: 'Not Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertNotSelectedValue',
     title: 'Not Selected Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertNotText',
     title: 'Not Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertElementPresent',
     title: 'Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertSelectedLabel',
     title: 'Selected Label',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertSelectedValue',
     title: 'Selected Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertText',
     title: 'Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'assertTitle',
     title: 'Title',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
-   browser.contextMenus.create({
+  browser.contextMenus.create({
     id: 'assertValue',
     title: 'Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'assert'
+    parentId: 'assert',
   })
   browser.contextMenus.create({
     id: 'store',
@@ -129,21 +129,21 @@ function createContextMenus() {
     title: 'Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'store'
+    parentId: 'store',
   })
   browser.contextMenus.create({
     id: 'storeTitle',
     title: 'Title',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'store'
+    parentId: 'store',
   })
-   browser.contextMenus.create({
+  browser.contextMenus.create({
     id: 'storeValue',
     title: 'Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'store'
+    parentId: 'store',
   })
   browser.contextMenus.create({
     id: 'verify',
@@ -156,91 +156,91 @@ function createContextMenus() {
     title: 'Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyEditable',
     title: 'Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyNotChecked',
     title: 'Not Checked',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyNotEditable',
     title: 'Not Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyElementNotPresent',
     title: 'Not Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyNotSelectedValue',
     title: 'Not Selected Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyNotText',
     title: 'Not Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyElementPresent',
     title: 'Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifySelectedLabel',
     title: 'Selected Label',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifySelectedValue',
     title: 'Selected Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyText',
     title: 'Text',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'verifyTitle',
     title: 'Title',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
-   browser.contextMenus.create({
+  browser.contextMenus.create({
     id: 'verifyValue',
     title: 'Value',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'verify'
+    parentId: 'verify',
   })
   browser.contextMenus.create({
     id: 'waitFor',
@@ -253,42 +253,42 @@ function createContextMenus() {
     title: 'Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
   browser.contextMenus.create({
     id: 'waitForElementNotEditable',
     title: 'Not Editable',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
   browser.contextMenus.create({
     id: 'waitForElementNotPresent',
     title: 'Not Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
   browser.contextMenus.create({
     id: 'waitForElementNotVisible',
     title: 'Not Visible',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
   browser.contextMenus.create({
     id: 'waitForElementPresent',
     title: 'Present',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
   browser.contextMenus.create({
     id: 'waitForElementVisible',
     title: 'Visible',
     documentUrlPatterns: ['<all_urls>'],
     contexts: ['all'],
-    parentId: 'waitFor'
+    parentId: 'waitFor',
   })
 }
 


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Fixes #867 

Adds all available Assert, Store, Verify and Wait For commands to the context menu (the menu that is shown when you right click on a page)

Currently only a small subset of these commands is available in this menu. This code allows you to choose the full set so that you can easily add any of these commands while recording a test

Since adding all these commands to a single menu would create an unmanageable (too long) menu, we have modified the menu to have two levels. The first level defines the action to take (Assert, Store, Verify, Wait For) and the second level specifies the details. See this image:

![Screen Shot 2019-11-09 at 07 20 06](https://user-images.githubusercontent.com/1383106/68524673-7601e200-02c1-11ea-90b6-24b19b940a2c.png)

We have added some comments to the PR to further explain what has been done