### PR TITLE
189 Add multi select, multi copy and multi paste

### DIFF
--- a/packages/selenium-ide/src/neo/IO/SideeX/record.js
+++ b/packages/selenium-ide/src/neo/IO/SideeX/record.js
@@ -127,13 +127,14 @@ export function recordCommand(command, target, value, index, select = false) {
   if (isEmpty(test.commands)) {
     addInitialCommands()
   }
-  const newCommand = test.createCommand(index ? index : getInsertionIndex(test))
+  let commandIndex = index ? index : getInsertionIndex(test)
+  const newCommand = test.createCommand(commandIndex)
   newCommand.setCommand(command)
   newCommand.setTarget(target)
   newCommand.setValue(value)
 
   if (select) {
-    UiState.selectCommand(newCommand)
+    UiState.selectCommand(newCommand, commandIndex)
   }
 
   UiState.lastRecordedCommand = newCommand

--- a/packages/selenium-ide/src/neo/components/TestTable/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestTable/index.jsx
@@ -40,6 +40,7 @@ export default class TestTable extends React.Component {
       this.props.commands,
       this.detectNewCommand
     )
+    this.selectCommandByRange = this.selectCommandByRange.bind(this)
     this.commandLevels = []
     this.node = null
   }
@@ -52,6 +53,9 @@ export default class TestTable extends React.Component {
     removeCommand: PropTypes.func,
     swapCommands: PropTypes.func,
     clearAllCommands: PropTypes.func,
+    clearSelectedCommands: PropTypes.func,
+    addToSelectedCommands: PropTypes.func,
+    selectedCommands: PropTypes.array,
   }
   detectNewCommand(change) {
     this.newCommand = change.added[0]
@@ -79,6 +83,27 @@ export default class TestTable extends React.Component {
   }
   handleScroll() {
     UiState.selectedTest.test.scrollY = this.node.scrollTop
+  }
+  selectCommandByRange(lastCommandSelected) {
+    if (this.props.selectedCommands.length > 1) {
+      const fromIndex = this.props.selectedCommands[
+        this.props.selectedCommands.length - 2
+      ].index
+      const toIndex = lastCommandSelected.index
+      if (fromIndex < toIndex) {
+        for (let i = fromIndex; i <= toIndex; i++) {
+          UiState.selectCommand(this.props.commands[i], i, {
+            isCommandTarget: false,
+          })
+        }
+      } else {
+        for (let i = fromIndex; i >= toIndex; i--) {
+          UiState.selectCommand(this.props.commands[i], i, {
+            isCommandTarget: false,
+          })
+        }
+      }
+    }
   }
   render() {
     if (this.props.commands)
@@ -130,8 +155,16 @@ export default class TestTable extends React.Component {
                             ).state
                           : ''
                       )}
-                      selected={this.props.selectedCommand === command.id}
+                      selected={
+                        this.props.selectedCommand === command.id ||
+                        !!this.props.selectedCommands.find(
+                          cmd => cmd.id === command.id
+                        )
+                      }
+                      focus={this.props.selectedCommand === command.id}
                       readOnly={PlaybackState.isPlaying}
+                      addToSelectedCommands={this.props.addToSelectedCommands}
+                      clearSelectedCommands={this.props.clearSelectedCommands}
                       singleCommandExecutionEnabled={
                         PlaybackState.isSingleCommandExecutionEnabled
                       }
@@ -155,6 +188,7 @@ export default class TestTable extends React.Component {
                       pasteFromClipboard={UiState.pasteFromClipboard}
                       clearAllCommands={this.props.clearAllCommands}
                       setSectionFocus={UiState.setSectionFocus}
+                      selectByRange={this.selectCommandByRange}
                       level={this.commandLevels[index]}
                     />
                   ))
@@ -162,6 +196,10 @@ export default class TestTable extends React.Component {
                     <TestRow
                       key={UiState.displayedTest.id}
                       selected={
+                        this.props.selectedCommand ===
+                        UiState.pristineCommand.id
+                      }
+                      focus={
                         this.props.selectedCommand ===
                         UiState.pristineCommand.id
                       }
@@ -174,6 +212,9 @@ export default class TestTable extends React.Component {
                       moveSelection={UiState.selectCommandByIndex}
                       pasteFromClipboard={UiState.pasteFromClipboard}
                       setSectionFocus={UiState.setSectionFocus}
+                      addToSelectedCommands={this.props.addToSelectedCommands}
+                      clearSelectedCommands={this.props.clearSelectedCommands}
+                      selectByRange={this.selectCommandByRange}
                     />
                   )
               : null}

--- a/packages/selenium-ide/src/neo/containers/Editor/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Editor/index.jsx
@@ -50,16 +50,19 @@ export default class Editor extends React.Component {
       return newCommand
     }
   }
-  removeCommand(index, command) {
+  removeCommand(index) {
     const { test } = this.props
-    test.removeCommand(command)
-    if (UiState.selectedCommand === command) {
+    UiState.selectedCommands.forEach(command => test.removeCommand(command))
+    if (UiState.selectedCommands.indexOf(UiState.selectedCommand) > -1) {
       if (test.commands.length > index) {
-        UiState.selectCommand(test.commands[index])
+        UiState.selectCommand(test.commands[index], index)
       } else if (test.commands.length) {
-        UiState.selectCommand(test.commands[test.commands.length - 1])
+        UiState.selectCommand(
+          test.commands[test.commands.length - 1],
+          test.commands.length - 1
+        )
       } else {
-        UiState.selectCommand(UiState.pristineCommand)
+        UiState.selectCommand(UiState.pristineCommand, 0)
       }
     }
   }
@@ -94,6 +97,9 @@ export default class Editor extends React.Component {
           selectedCommand={
             UiState.selectedCommand ? UiState.selectedCommand.id : null
           }
+          selectedCommands={UiState.selectedCommands}
+          addToSelectedCommands={UiState.addToSelectedCommands}
+          clearSelectedCommands={UiState.clearSelectedCommands}
           selectCommand={UiState.selectCommand}
           addCommand={this.addCommand}
           removeCommand={this.removeCommand}

--- a/packages/selenium-ide/src/neo/containers/Panel/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Panel/index.jsx
@@ -109,6 +109,7 @@ export default class Panel extends React.Component {
   constructor(props) {
     super(props)
     this.state = { project }
+    this.selectAllCommands = this.selectAllCommands.bind(this)
     this.parseKeyDown = this.parseKeyDown.bind(this)
     this.keyDownHandler = window.document.body.onkeydown = this.handleKeyDown.bind(
       this
@@ -170,6 +171,14 @@ export default class Panel extends React.Component {
     } else if (keyComb.onlyPrimary && keyComb.key === 'O' && this.openFile) {
       e.preventDefault()
       this.openFile()
+    } else if (
+      keyComb.onlyPrimary &&
+      keyComb.key === 'A' &&
+      e.target.localName !== 'input' &&
+      e.target.localName !== 'textarea'
+    ) {
+      e.preventDefault()
+      this.selectAllCommands()
     } else if (keyComb.onlyPrimary && keyComb.key === '1') {
       // test view
       e.preventDefault()
@@ -278,9 +287,21 @@ export default class Panel extends React.Component {
       window.removeEventListener('beforeunload', this.quitHandler)
     }
   }
+  onClick() {
+    UiState.clearSelectedCommands()
+  }
+  selectAllCommands() {
+    UiState.clearSelectedCommands()
+    UiState.selectCommandByIndex(0)
+    UiState.selectAllCommands()
+  }
   render() {
     return (
-      <div className="container" onKeyDown={this.handleKeyDownAlt.bind(this)}>
+      <div
+        className="container"
+        onKeyDown={this.handleKeyDownAlt.bind(this)}
+        onClick={this.onClick.bind(this)}
+      >
         <SuiteDropzone
           loadProject={loadProject.bind(undefined, this.state.project)}
         >


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Fixes #189

I think that the functionality described in that issue is pretty fundamental. Being able to choose several steps to copy and paste is a must, otherwise sharing steps between tests is just a huge pain if you have to do it one by one

This code is based on the work already done by @Jongkeun in https://github.com/SeleniumHQ/selenium-ide/pull/241, so many thanks to him. I just did two things:
- Modify the code to match the new prettier linting rules
- Fix several small issues which were preventing this code from running correctly

I have tested it extensively and seems to be working fine, any feedback welcome

This not only allows you to copy/paste steps within a test, it allows you to copy them to a new test or even a new project