### PR TITLE
775 Add a confirmation dialog before loading a new project

### DIFF
--- a/packages/selenium-ide/src/neo/containers/Panel/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Panel/index.jsx
@@ -270,6 +270,35 @@ export default class Panel extends React.Component {
     Logger.clearLogs()
     newProject.setModified(false)
   }
+  async doLoadProject(file) {
+    if (!UiState.isSaved()) {
+      const choseProceed = await ModalState.showAlert({
+        title: 'Load without saving',
+        description:
+          'Are you sure you would like to load a new project without saving the current one?',
+        confirmLabel: 'proceed',
+        cancelLabel: 'cancel',
+      })
+      if (choseProceed) {
+        await UiState.stopRecording({ nameNewTest: false })
+        loadProject(this.state.project, file)
+      }
+    } else if (UiState.isRecording) {
+      const choseProceed = await ModalState.showAlert({
+        title: 'Stop recording',
+        description:
+          'Leaving this project and loading a new one will stop the recording process. Would you like to continue?',
+        confirmLabel: 'proceed',
+        cancelLabel: 'cancel',
+      })
+      if (choseProceed) {
+        await UiState.stopRecording({ nameNewTest: false })
+        loadProject(this.state.project, file)
+      }
+    } else {
+      loadProject(this.state.project, file)
+    }
+  }
 
   componentWillUnmount() {
     if (isProduction) {
@@ -281,9 +310,7 @@ export default class Panel extends React.Component {
   render() {
     return (
       <div className="container" onKeyDown={this.handleKeyDownAlt.bind(this)}>
-        <SuiteDropzone
-          loadProject={loadProject.bind(undefined, this.state.project)}
-        >
+        <SuiteDropzone loadProject={this.doLoadProject.bind(this)}>
           <SplitPane
             split="horizontal"
             minSize={UiState.minContentHeight}
@@ -303,7 +330,7 @@ export default class Panel extends React.Component {
                 openFile={openFile => {
                   this.openFile = openFile
                 }}
-                load={loadProject.bind(undefined, this.state.project)}
+                load={this.doLoadProject.bind(this)}
                 save={() => saveProject(this.state.project)}
                 new={this.loadNewProject.bind(this)}
               />


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Fixes #775

Adds a confirmation dialog when you try to load a new project and you have unsaved changes or the project is recording. 

Unfortunately, due to the way that they load functionality is implemented, I have only been able to add this confirmation dialog *after* you select the file that you want to load, but I think this should be acceptable.

Works fine as well when dragging and dropping project files into the selenium window