### PR TITLE
Add WaitForText to the context menu

### DIFF
--- a/packages/selenium-ide/src/neo/side-effects/contextMenu.js
+++ b/packages/selenium-ide/src/neo/side-effects/contextMenu.js
@@ -290,6 +290,13 @@ function createContextMenus() {
     contexts: ['all'],
     parentId: 'waitFor',
   })
+  browser.contextMenus.create({
+    id: 'waitForText',
+    title: 'Text',
+    documentUrlPatterns: ['<all_urls>'],
+    contexts: ['all'],
+    parentId: 'waitFor',
+  })
 }
 
 function destroyContextMenus() {


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added the WaitForText command to the context menu

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now that we have incorporated the new WaitForText command and now that we are showing all commands in the context menu, we need to add this new command to the context menu

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
