### PR TITLE
Export emitCommand from export-code

### DIFF
--- a/packages/code-export-csharp-nunit/src/index.js
+++ b/packages/code-export-csharp-nunit/src/index.js
@@ -118,6 +118,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-csharp-xunit/src/index.js
+++ b/packages/code-export-csharp-xunit/src/index.js
@@ -160,6 +160,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-java-junit/src/index.js
+++ b/packages/code-export-java-junit/src/index.js
@@ -118,6 +118,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-javascript-mocha/src/index.js
+++ b/packages/code-export-javascript-mocha/src/index.js
@@ -118,6 +118,7 @@ export default {
   emit: {
     test: emitTest,
     suite: emitSuite,
+    command: emitter.emit,
     locator: location.emit,
   },
   register: {

--- a/packages/code-export-python-pytest/src/index.js
+++ b/packages/code-export-python-pytest/src/index.js
@@ -120,6 +120,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-ruby-rspec/src/index.js
+++ b/packages/code-export-ruby-rspec/src/index.js
@@ -120,6 +120,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -92,7 +92,7 @@ export function emitCommand(language, { command, target, value }) {
   return availableLanguages[language].default.emit.command({
     command,
     target,
-    value
+    value,
   })
 }
 

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -88,6 +88,15 @@ export function emitSuite(
   })
 }
 
+export function emitCommand(language, { command, target, value }) {
+  console.log(availableLanguages[language].default)
+  return availableLanguages[language].default.emit.command({
+    command,
+    target,
+    value
+  })
+}
+
 export function emitLocator(language, input) {
   return availableLanguages[language].default.emit.locator(input)
 }
@@ -107,6 +116,7 @@ export default {
   emit: {
     test: emitTest,
     suite: emitSuite,
+    command: emitCommand,
     locator: emitLocator,
   },
 }

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -89,7 +89,6 @@ export function emitSuite(
 }
 
 export function emitCommand(language, { command, target, value }) {
-  console.log(availableLanguages[language].default)
   return availableLanguages[language].default.emit.command({
     command,
     target,


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->

**Thanks for contributing to the Selenium IDE!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Simply export the functions which code-export on a 'per command' basis.

### Motivation and Context
I have already made and merged a PR for the selianize package, which does the same thing.

Please see the PR here. https://github.com/SeleniumHQ/selenium-ide/pull/538

The motivation is the same, I am working on a project which needs to translate side commands to selenium webdriver commands with more control than what is possible with the 'test-suite' generation style.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
