### PR TITLE
925 properly save the handlers so that they are correctly removed

### DIFF
--- a/packages/selenium-ide/src/content/record-api.js
+++ b/packages/selenium-ide/src/content/record-api.js
@@ -102,12 +102,9 @@ Recorder.prototype.attach = function() {
       const handlers = Recorder.eventHandlers[eventKey]
       this.eventListeners[eventKey] = []
       for (let i = 0; i < handlers.length; i++) {
-        this.window.document.addEventListener(
-          eventName,
-          handlers[i].bind(this),
-          capture
-        )
-        this.eventListeners[eventKey].push(handlers[i])
+        let handler = handlers[i].bind(this)
+        this.window.document.addEventListener(eventName, handler, capture)
+        this.eventListeners[eventKey].push(handler)
       }
     }
     for (let observerName in Recorder.mutationObservers) {


### PR DESCRIPTION
Properly save the event handlers so that they can be removed when recording is stopped
Fixes #925 

### Description
When setting the event handlers we were adding them with `.bind(this)` but then we saved them without this, this made the signature of the event handler different and when trying to remove them they would not be removed

### Motivation and Context
When recording, if you stop recording and then start recording again, the event listeners are not properly removed, so we end up duplicating them, which results in recording commands more than once

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
