### PR TITLE
927 Fix click handling after starting and stopping

### DIFF
--- a/packages/selenium-ide/src/content/record.js
+++ b/packages/selenium-ide/src/content/record.js
@@ -295,6 +295,8 @@ Recorder.addEventHandler(
   'dragAndDrop',
   'mousedown',
   function(event) {
+    mousedown = undefined
+    selectMousedown = undefined
     if (
       event.clientX < window.document.documentElement.clientWidth &&
       event.clientY < window.document.documentElement.clientHeight
@@ -425,8 +427,12 @@ Recorder.addEventHandler(
     } else {
       clickLocator = undefined
       mouseup = undefined
-      let x = event.clientX - mousedown.clientX
-      let y = event.clientY - mousedown.clientY
+      let x = 0
+      let y = 0
+      if (mousedown) {
+        x = event.clientX - mousedown.clientX
+        y = event.clientY - mousedown.clientY
+      }
 
       if (mousedown && mousedown.target !== event.target && !(x + y)) {
         record('mouseDown', locatorBuilders.buildAll(mousedown.target), '')


### PR DESCRIPTION
Properly initialise the variables that are used to detect if a click is drag and drop after stopping and restarting the recorder

### Description
When recording a test, if you stop recording and restart, the variables that are used to detect if we are drag and dropping are not initialised which means that after the restart a normal click will be recorded as a drag and drop event. We fix this by properly initialising these variables

### Motivation and Context
Fixes #927 

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
