### PR TITLE
980 correctly handle the case where the element is not available yet in the "Wait for text" command

### DIFF
--- a/packages/selenium-ide/src/content/selenium-api.js
+++ b/packages/selenium-ide/src/content/selenium-api.js
@@ -2510,7 +2510,7 @@ function isText(locator, text) {
   try {
     return this.isText(locator, text)
   } catch (error) {
-    unableToLocateTargetElementError()
+    return false
   }
 }
 
@@ -2524,7 +2524,7 @@ Selenium.prototype.isText = function(locator, text) {
    */
   let element = this.browserbot.findElement(locator)
   let elementText = bot.dom.getVisibleText(element).trim()
-  return elementText == text
+  return elementText === text
 }
 
 Selenium.prototype.getAllButtons = function() {


### PR DESCRIPTION
### Description. 
If an element is not located while waiting for text we need to keep waiting until the timeout is reached as it can happen that the element has not been added to the page yet

Also fixes the test for this text to use strict equality
### Motivation and Context
When waiting for text if the element could not be located we would throw an exception and this would stop the waiting
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

