### PR TITLE
Accessibility fix ( long test names can be scrolled into view )

### DIFF
--- a/packages/selenium-ide/src/neo/components/TestList/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestList/index.jsx
@@ -40,7 +40,9 @@ export default class TestList extends Component {
   }
   render() {
     return (
-      <div className={classNames('tests_div', { active: !this.props.collapsed })}>
+      <div
+        className={classNames('tests_div', { active: !this.props.collapsed })}
+      >
         <ul className={classNames('tests')}>
           {this.props.tests.map((test, index) => (
             <li key={test.id}>

--- a/packages/selenium-ide/src/neo/components/TestList/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestList/index.jsx
@@ -40,8 +40,8 @@ export default class TestList extends Component {
   }
   render() {
     return (
-      <div className={'tests_div'}>
-        <ul className={classNames('tests', { active: !this.props.collapsed })}>
+      <div className={classNames('tests_div', { active: !this.props.collapsed })}>
+        <ul className={classNames('tests')}>
           {this.props.tests.map((test, index) => (
             <li key={test.id}>
               {this.props.noMenu ? (

--- a/packages/selenium-ide/src/neo/components/TestList/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TestList/index.jsx
@@ -40,142 +40,144 @@ export default class TestList extends Component {
   }
   render() {
     return (
-      <ul className={classNames('tests', { active: !this.props.collapsed })}>
-        {this.props.tests.map((test, index) => (
-          <li key={test.id}>
-            {this.props.noMenu ? (
-              <Test
-                key={test.id}
-                className={PlaybackState.testState.get(test.id)}
-                callstack={
-                  PlaybackState.stackCaller === test
-                    ? PlaybackState.callstack
-                    : undefined
-                }
-                selectedStackIndex={
-                  PlaybackState.stackCaller === test
-                    ? UiState.selectedTest.stack
-                    : undefined
-                }
-                index={index}
-                test={test}
-                suite={this.props.suite}
-                selected={
-                  UiState.selectedTest.test &&
-                  test.id === UiState.selectedTest.test.id
-                }
-                isExecuting={
-                  PlaybackState.isPlaying &&
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id
-                }
-                paused={
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id &&
-                  PlaybackState.paused
-                }
-                changed={test.modified}
-                selectTest={UiState.selectTest}
-                moveSelectionUp={() => {
-                  UiState.selectTestByIndex(index - 1)
-                }}
-                moveSelectionDown={() => {
-                  UiState.selectTestByIndex(index + 1)
-                }}
-                setSectionFocus={UiState.setSectionFocus}
-              />
-            ) : this.props.suite ? (
-              <DraggableTest
-                className={PlaybackState.testState.get(test.id)}
-                index={index}
-                test={test}
-                suite={this.props.suite}
-                selected={
-                  UiState.selectedTest.test &&
-                  test.id === UiState.selectedTest.test.id &&
-                  this.props.suite.id ===
-                    (UiState.selectedTest.suite
-                      ? UiState.selectedTest.suite.id
-                      : undefined)
-                }
-                isExecuting={
-                  PlaybackState.isPlaying &&
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id
-                }
-                paused={
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id &&
-                  PlaybackState.paused
-                }
-                changed={test.modified}
-                selectTest={UiState.selectTest}
-                removeTest={
-                  this.props.removeTest
-                    ? () => {
-                        this.props.removeTest(test)
-                      }
-                    : undefined
-                }
-                swapTests={this.props.suite.swapTestCases}
-                moveSelectionUp={() => {
-                  UiState.selectTestByIndex(index - 1, this.props.suite)
-                }}
-                moveSelectionDown={() => {
-                  UiState.selectTestByIndex(index + 1, this.props.suite)
-                }}
-                setSectionFocus={UiState.setSectionFocus}
-              />
-            ) : (
-              <MenuTest
-                key={test.id}
-                className={PlaybackState.testState.get(test.id)}
-                index={index}
-                test={test}
-                selected={
-                  UiState.selectedTest.test &&
-                  test.id === UiState.selectedTest.test.id
-                }
-                isExecuting={
-                  PlaybackState.isPlaying &&
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id
-                }
-                paused={
-                  PlaybackState.stackCaller &&
-                  PlaybackState.stackCaller.id === test.id &&
-                  PlaybackState.paused
-                }
-                changed={test.modified}
-                selectTest={UiState.selectTest}
-                renameTest={this.props.renameTest}
-                duplicateTest={() => {
-                  this.props.duplicateTest(test)
-                }}
-                removeTest={
-                  this.props.removeTest
-                    ? () => {
-                        this.props.removeTest(test)
-                      }
-                    : undefined
-                }
-                codeExport={() => {
-                  this.props.codeExport({
-                    test: test.export(),
-                  })
-                }}
-                moveSelectionUp={() => {
-                  UiState.selectTestByIndex(index - 1)
-                }}
-                moveSelectionDown={() => {
-                  UiState.selectTestByIndex(index + 1)
-                }}
-                setSectionFocus={UiState.setSectionFocus}
-              />
-            )}
-          </li>
-        ))}
-      </ul>
+      <div className={'tests_div'}>
+        <ul className={classNames('tests', { active: !this.props.collapsed })}>
+          {this.props.tests.map((test, index) => (
+            <li key={test.id}>
+              {this.props.noMenu ? (
+                <Test
+                  key={test.id}
+                  className={PlaybackState.testState.get(test.id)}
+                  callstack={
+                    PlaybackState.stackCaller === test
+                      ? PlaybackState.callstack
+                      : undefined
+                  }
+                  selectedStackIndex={
+                    PlaybackState.stackCaller === test
+                      ? UiState.selectedTest.stack
+                      : undefined
+                  }
+                  index={index}
+                  test={test}
+                  suite={this.props.suite}
+                  selected={
+                    UiState.selectedTest.test &&
+                    test.id === UiState.selectedTest.test.id
+                  }
+                  isExecuting={
+                    PlaybackState.isPlaying &&
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id
+                  }
+                  paused={
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id &&
+                    PlaybackState.paused
+                  }
+                  changed={test.modified}
+                  selectTest={UiState.selectTest}
+                  moveSelectionUp={() => {
+                    UiState.selectTestByIndex(index - 1)
+                  }}
+                  moveSelectionDown={() => {
+                    UiState.selectTestByIndex(index + 1)
+                  }}
+                  setSectionFocus={UiState.setSectionFocus}
+                />
+              ) : this.props.suite ? (
+                <DraggableTest
+                  className={PlaybackState.testState.get(test.id)}
+                  index={index}
+                  test={test}
+                  suite={this.props.suite}
+                  selected={
+                    UiState.selectedTest.test &&
+                    test.id === UiState.selectedTest.test.id &&
+                    this.props.suite.id ===
+                      (UiState.selectedTest.suite
+                        ? UiState.selectedTest.suite.id
+                        : undefined)
+                  }
+                  isExecuting={
+                    PlaybackState.isPlaying &&
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id
+                  }
+                  paused={
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id &&
+                    PlaybackState.paused
+                  }
+                  changed={test.modified}
+                  selectTest={UiState.selectTest}
+                  removeTest={
+                    this.props.removeTest
+                      ? () => {
+                          this.props.removeTest(test)
+                        }
+                      : undefined
+                  }
+                  swapTests={this.props.suite.swapTestCases}
+                  moveSelectionUp={() => {
+                    UiState.selectTestByIndex(index - 1, this.props.suite)
+                  }}
+                  moveSelectionDown={() => {
+                    UiState.selectTestByIndex(index + 1, this.props.suite)
+                  }}
+                  setSectionFocus={UiState.setSectionFocus}
+                />
+              ) : (
+                <MenuTest
+                  key={test.id}
+                  className={PlaybackState.testState.get(test.id)}
+                  index={index}
+                  test={test}
+                  selected={
+                    UiState.selectedTest.test &&
+                    test.id === UiState.selectedTest.test.id
+                  }
+                  isExecuting={
+                    PlaybackState.isPlaying &&
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id
+                  }
+                  paused={
+                    PlaybackState.stackCaller &&
+                    PlaybackState.stackCaller.id === test.id &&
+                    PlaybackState.paused
+                  }
+                  changed={test.modified}
+                  selectTest={UiState.selectTest}
+                  renameTest={this.props.renameTest}
+                  duplicateTest={() => {
+                    this.props.duplicateTest(test)
+                  }}
+                  removeTest={
+                    this.props.removeTest
+                      ? () => {
+                          this.props.removeTest(test)
+                        }
+                      : undefined
+                  }
+                  codeExport={() => {
+                    this.props.codeExport({
+                      test: test.export(),
+                    })
+                  }}
+                  moveSelectionUp={() => {
+                    UiState.selectTestByIndex(index - 1)
+                  }}
+                  moveSelectionDown={() => {
+                    UiState.selectTestByIndex(index + 1)
+                  }}
+                  setSectionFocus={UiState.setSectionFocus}
+                />
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
     )
   }
 }

--- a/packages/selenium-ide/src/neo/components/TestList/style.css
+++ b/packages/selenium-ide/src/neo/components/TestList/style.css
@@ -1,5 +1,6 @@
 .tests {
   max-height: 100%;
+  min-width: 100%;
   overflow-y: auto;
   transition: max-height 300ms linear;
   list-style: none;

--- a/packages/selenium-ide/src/neo/components/TestList/style.css
+++ b/packages/selenium-ide/src/neo/components/TestList/style.css
@@ -1,9 +1,14 @@
 .tests {
   max-height: 0;
-  overflow-x: hidden;
   overflow-y: auto;
   transition: max-height 300ms linear;
   list-style: none;
+  display: table;
+}
+
+.tests_div {
+  overflow-x: scroll;
+  flex-grow: 1;
 }
 
 .tests.active {
@@ -13,4 +18,5 @@
 
 .tests li {
   margin: 7px 0;
+  display: block;
 }

--- a/packages/selenium-ide/src/neo/components/TestList/style.css
+++ b/packages/selenium-ide/src/neo/components/TestList/style.css
@@ -1,5 +1,5 @@
 .tests {
-  max-height: 0;
+  max-height: 100%;
   overflow-y: auto;
   transition: max-height 300ms linear;
   list-style: none;
@@ -8,12 +8,18 @@
 
 .tests_div {
   overflow-x: scroll;
+  transition: max-height 300ms linear;
+  max-height: 0;
   flex-grow: 1;
+}
+
+.tests_div.active {
+  max-height: 100%;
+  transition: max-height 300ms linear;
 }
 
 .tests.active {
   max-height: 100%;
-  transition: max-height 300ms linear;
 }
 
 .tests li {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

If test names overflow parent container in x direction, container will be scrollable.

### Motivation and Context

I want to see long test names....


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
