### PR TITLE
Fix `pause` output when exporting Python code

### DIFF
--- a/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
+++ b/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
@@ -225,7 +225,7 @@ actions.move_to_element(element).release().perform()"
 
 exports[`command code emitter should emit \`open\` with absolute url 1`] = `"self.driver.get(\\"https://www.seleniumhq.org/\\")"`;
 
-exports[`command code emitter should emit \`pause\` command 1`] = `"time.sleep(300)"`;
+exports[`command code emitter should emit \`pause\` command 1`] = `"time.sleep(0.3)"`;
 
 exports[`command code emitter should emit \`remove selection\` command 1`] = `
 "dropdown = self.driver.find_element(By.CSS_SELECTOR, \\"select\\")

--- a/packages/code-export-python-pytest/src/command.js
+++ b/packages/code-export-python-pytest/src/command.js
@@ -485,7 +485,8 @@ function emitOpen(target) {
 }
 
 async function emitPause(time) {
-  const commands = [{ level: 0, statement: `time.sleep(${time})` }]
+  const sec = time / 1000
+  const commands = [{ level: 0, statement: `time.sleep(${sec})` }]
   return Promise.resolve({ commands })
 }
 


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->

**Thanks for contributing to the Selenium IDE!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
When exporting Python code, the value of pause is output as `time.sleep` exactly as it is.
However, Python's `time.sleep` accepts seconds, not milliseconds, so the value should be converted as milliseconds value.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
  - update snapshot
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
