### PR TITLE
Changed style of test-selector list to display block

### DIFF
--- a/packages/selenium-ide/src/neo/components/Dialogs/TestSelector/style.css
+++ b/packages/selenium-ide/src/neo/components/Dialogs/TestSelector/style.css
@@ -8,4 +8,5 @@
   overflow: auto;
   max-height: initial;
   padding: 0;
+  display: block;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
If a project has many tests and a user tries to add tests to a test suite the list will make the dialog window longer than the window itself. Currently, there is a max-height set at 250px but it's not doing anything since the list is inheriting display: table from .test. This change is just adding display: block to the list in the test selector to fix this. Solves #1013

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Answered above.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
