### PR TITLE
Fix Python emitEcho with combination of string and variable

### DIFF
--- a/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
+++ b/packages/code-export-python-pytest/__test__/src/__snapshots__/command.spec.js.snap
@@ -123,9 +123,9 @@ actions = ActionChains(self.driver)
 actions.drag_and_drop(dragged, dropped).perform()"
 `;
 
-exports[`command code emitter should emit \`echo\` command 1`] = `"print(str(\\"blah\\"))"`;
+exports[`command code emitter should emit \`echo\` command 1`] = `"print(\\"blah\\")"`;
 
-exports[`command code emitter should emit \`echo\` command with variables 1`] = `"print(str(self.vars[\\"blah\\"]))"`;
+exports[`command code emitter should emit \`echo\` command with variables 1`] = `"print(\\"blah = {}\\".format(self.vars[\\"blah\\"]))"`;
 
 exports[`command code emitter should emit \`edit content\` command 1`] = `
 "element = self.driver.find_element(By.ID, \\"contentEditable\\")

--- a/packages/code-export-python-pytest/__test__/src/command.spec.js
+++ b/packages/code-export-python-pytest/__test__/src/command.spec.js
@@ -272,7 +272,7 @@ describe('command code emitter', () => {
   it('should emit `echo` command with variables', () => {
     const command = {
       command: 'echo',
-      target: '${blah}',
+      target: 'blah = ${blah}',
       value: '',
     }
     return expect(prettify(command)).resolves.toMatchSnapshot()

--- a/packages/code-export-python-pytest/src/command.js
+++ b/packages/code-export-python-pytest/src/command.js
@@ -381,9 +381,21 @@ async function emitDragAndDrop(dragged, dropped) {
   return Promise.resolve({ commands })
 }
 
+function translateToPythonString(str) {
+  const regExp = /self.vars\["\w+"]/
+  const vars = str.match(regExp)
+
+  if (vars && vars.length > 0) {
+    const fmtStr = str.replace(regExp, '{}')
+    return `"${fmtStr}".format(${vars.join(', ')})`
+  }
+
+  return `"${str}"`
+}
+
 async function emitEcho(message) {
-  const _message = message.startsWith('self.vars[') ? message : `"${message}"`
-  return Promise.resolve(`print(str(${_message}))`)
+  const _message = translateToPythonString(message)
+  return Promise.resolve(`print(${_message})`)
 }
 
 async function emitEditContent(locator, content) {


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fix issue https://github.com/SeleniumHQ/selenium-ide/issues/939.

Echo with multiple variables is not supported yet.
It requires fixing `defaultPreprocessor`, which seems difficult.
So, multiple-variable support is out of scope in this PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
