### PR TITLE
Fixing various accessibility issues

### DIFF
--- a/packages/selenium-ide/src/neo/components/ActionButtons/More/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/More/index.jsx
@@ -27,7 +27,7 @@ export default class MoreButton extends React.Component {
     return (
       <ActionButton
         tabIndex={this.props.canFocus ? '0' : '-1'}
-        aria-expended={this.props.isMenuOpen}
+        aria-expanded={this.props.isMenuOpen}
         {...props}
         className={classNames(
           { 'no-focus': !this.props.canFocus },

--- a/packages/selenium-ide/src/neo/components/ActionButtons/More/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/More/index.jsx
@@ -27,6 +27,7 @@ export default class MoreButton extends React.Component {
     return (
       <ActionButton
         tabIndex={this.props.canFocus ? '0' : '-1'}
+        aria-expended={this.props.isMenuOpen}
         {...props}
         className={classNames(
           { 'no-focus': !this.props.canFocus },

--- a/packages/selenium-ide/src/neo/components/AutoComplete/index.jsx
+++ b/packages/selenium-ide/src/neo/components/AutoComplete/index.jsx
@@ -76,7 +76,9 @@ export default class AutoComplete extends React.Component {
           )
         }}
         renderItem={(item, isHighlighted) => {
-          var itemKey = this.props.getItemKey ? this.props.getItemKey(item) : item
+          var itemKey = this.props.getItemKey
+            ? this.props.getItemKey(item)
+            : item
           var idItem = `${this.id}_${itemKey}`
           var input
           if (

--- a/packages/selenium-ide/src/neo/components/AutoComplete/index.jsx
+++ b/packages/selenium-ide/src/neo/components/AutoComplete/index.jsx
@@ -76,9 +76,8 @@ export default class AutoComplete extends React.Component {
           )
         }}
         renderItem={(item, isHighlighted) => {
-          var idItem = `${this.id}_${
-            this.props.getItemKey ? this.props.getItemKey(item) : item
-          }`
+          var itemKey = this.props.getItemKey ? this.props.getItemKey(item) : item
+          var idItem = `${this.id}_${itemKey}`
           var input
           if (
             this.spanRef.current &&
@@ -93,7 +92,8 @@ export default class AutoComplete extends React.Component {
           return (
             <li
               id={idItem}
-              key={this.props.getItemKey ? this.props.getItemKey(item) : item}
+              key={itemKey}
+              aria-label={itemKey}
               style={{
                 background: isHighlighted ? '#5c5c5c' : 'white',
                 color: isHighlighted ? 'white' : '#3f3f3f',

--- a/packages/selenium-ide/src/neo/components/Suite/index.jsx
+++ b/packages/selenium-ide/src/neo/components/Suite/index.jsx
@@ -96,7 +96,7 @@ class Suite extends React.Component {
       <ListMenu
         width={130}
         padding={-5}
-        opener={<MoreButton aria-label="More options" />}
+        opener={<MoreButton aria-label="More options" canFocus={true} />}
       >
         <ListMenuItem onClick={this.props.selectTests}>Add tests</ListMenuItem>
         <ListMenuItem

--- a/packages/selenium-ide/src/neo/components/Suite/style.css
+++ b/packages/selenium-ide/src/neo/components/Suite/style.css
@@ -47,6 +47,10 @@
   opacity: 1;
 }
 
+.project:focus button {
+  opacity: 1;
+}
+
 .projects .test > button {
   font-size: 18px;
 }

--- a/packages/selenium-ide/src/neo/components/Test/index.jsx
+++ b/packages/selenium-ide/src/neo/components/Test/index.jsx
@@ -305,7 +305,7 @@ export class MenuTest extends React.Component {
       <ListMenu
         width={130}
         padding={-5}
-        opener={<MoreButton aria-label="More options" />}
+        opener={<MoreButton aria-label="More options" canFocus={true} />}
       >
         <ListMenuItem
           onClick={() =>

--- a/packages/selenium-ide/src/neo/components/Test/style.css
+++ b/packages/selenium-ide/src/neo/components/Test/style.css
@@ -30,6 +30,10 @@
   opacity: 1;
 }
 
+.test:focus .name > button {
+  opacity: 1;
+}
+
 .test > a {
   cursor: pointer;
   border-top: 1px solid transparent;

--- a/packages/selenium-ide/src/neo/components/VerticalTabBar/style.css
+++ b/packages/selenium-ide/src/neo/components/VerticalTabBar/style.css
@@ -34,11 +34,11 @@
 
 .tabbar.vertical a:hover {
   color: #0c0c0c;
-  background-color: #fff;
+  background-color: #d8ebfb;
 }
 
 .tabbar.vertical a:focus {
-  background-color: #fff;
+  background-color: #d8ebfb;
 }
 
 .tabbar.vertical a:focus > span {

--- a/packages/selenium-ide/src/neo/components/VerticalTabBar/style.css
+++ b/packages/selenium-ide/src/neo/components/VerticalTabBar/style.css
@@ -34,11 +34,11 @@
 
 .tabbar.vertical a:hover {
   color: #0c0c0c;
-  background-color: #f3f3f3;
+  background-color: #fff;
 }
 
 .tabbar.vertical a:focus {
-  background-color: #f3f3f3;
+  background-color: #fff;
 }
 
 .tabbar.vertical a:focus > span {


### PR DESCRIPTION
### Description
We used our Accessiblity test resources to verify the accessibility levels of the Selenium IDE and we've found a list of issues. The PR is going to address some of the issues.

### Motivation and Context
This pr is going to fix below issues:
1. Aria label is missing for all the commands in the command dropdown, so people use narrator cannot hear the command names of the dropdown items. https://github.com/SeleniumHQ/selenium-ide/issues/1181
2. Couple "More options" button does not have aria-expanded attribute so people use narrator cannot get the expanded/collapsed state of the "More options" button. https://github.com/SeleniumHQ/selenium-ide/issues/1182
3. "More options" buttons of "Test" or "Test suite" cannot be accessed by keyboard since they are only show when mouse hover over and they cannot be focused.  We make it be able to focused by keyboard tab and show up when focused. https://github.com/SeleniumHQ/selenium-ide/issues/1184
4. There's no focus indicator when the header bar of the Test/Test suite pane is in focus which brings trouble for people use keyboard for navigation only. we changed the background color to the light blue which used in other element is focused. https://github.com/SeleniumHQ/selenium-ide/issues/1183

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

