### PR TITLE
Add arrow key controlling for switching the Console tab bar.

### DIFF
--- a/packages/selenium-ide/src/neo/components/CommandReference/index.js
+++ b/packages/selenium-ide/src/neo/components/CommandReference/index.js
@@ -27,9 +27,9 @@ export default class CommandReference extends React.Component {
     children: PropTypes.node,
     currentCommand: PropTypes.object,
   }
-  unknownCommand() {
+  unknownCommand(props) {
     return (
-      <div className={classNames('command-reference', 'unknown-command')}>
+      <div className={classNames('command-reference', 'unknown-command')} {...props}>
         <strong>Unknown command name provided.</strong>
       </div>
     )
@@ -118,11 +118,13 @@ export default class CommandReference extends React.Component {
     )
   }
   render() {
+    var props = {...this.props}
+    delete props.currentCommand;
     if (!(this.props.currentCommand && this.props.currentCommand.name)) {
-      return this.unknownCommand()
+      return this.unknownCommand(props)
     } else {
       return (
-        <div className="command-reference">
+        <div className="command-reference" {...props}>
           <ul>
             {this.props.currentCommand.name && this.commandSignature()}
             {this.props.currentCommand.description && (

--- a/packages/selenium-ide/src/neo/components/CommandReference/index.js
+++ b/packages/selenium-ide/src/neo/components/CommandReference/index.js
@@ -29,7 +29,10 @@ export default class CommandReference extends React.Component {
   }
   unknownCommand(props) {
     return (
-      <div className={classNames('command-reference', 'unknown-command')} {...props}>
+      <div
+        className={classNames('command-reference', 'unknown-command')}
+        {...props}
+      >
         <strong>Unknown command name provided.</strong>
       </div>
     )
@@ -118,8 +121,8 @@ export default class CommandReference extends React.Component {
     )
   }
   render() {
-    var props = {...this.props}
-    delete props.currentCommand;
+    var props = { ...this.props }
+    delete props.currentCommand
     if (!(this.props.currentCommand && this.props.currentCommand.name)) {
       return this.unknownCommand(props)
     } else {

--- a/packages/selenium-ide/src/neo/components/LogList/index.jsx
+++ b/packages/selenium-ide/src/neo/components/LogList/index.jsx
@@ -27,8 +27,11 @@ export default class LogList extends React.Component {
     this.props.scrollTo(10000)
   }
   render() {
+    var props = { ...this.props }
+    delete props.output
+    delete props.scrollTo
     return (
-      <div className="logs" id="Log">
+      <div className="logs" {...props}>
         <ul>
           {this.props.output.logs.map(log => (
             <LogMessage key={log.id} log={log} />

--- a/packages/selenium-ide/src/neo/components/TabBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TabBar/index.jsx
@@ -62,7 +62,7 @@ export default class TabBar extends React.Component {
     var delta = 0
     if (event.keyCode === 39) {
       delta = 1
-    } else if(event.keyCode === 37) {
+    } else if (event.keyCode === 37) {
       delta = -1
     }
     if (delta !== 0) {

--- a/packages/selenium-ide/src/neo/components/TabBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TabBar/index.jsx
@@ -23,12 +23,14 @@ import './style.css'
 export default class TabBar extends React.Component {
   constructor(props) {
     super(props)
-    var defaultIndex = props.defaultTab ? props.tabs.indexOf(props.defaultTab) : 0
+    var defaultIndex = props.defaultTab
+      ? props.tabs.indexOf(props.defaultTab)
+      : 0
     this.state = {
       activeTab: {
-            tab: props.defaultTab || props.tabs[defaultIndex],
-            index: defaultIndex,
-          },
+        tab: props.defaultTab || props.tabs[defaultIndex],
+        index: defaultIndex,
+      },
     }
     this.tabRefs = this.props.tabs.map(() => React.createRef())
     this.forcusIndex = defaultIndex
@@ -51,28 +53,33 @@ export default class TabBar extends React.Component {
       this.setState({
         activeTab: { tab, index },
       })
-      this.focusIndex = index;
+      this.focusIndex = index
       if (this.props.tabChanged) this.props.tabChanged(tab)
     }
     if (this.props.tabClicked) this.props.tabClicked(tab)
   }
   handleKeyDown(event) {
-    var delta = 0;
+    var delta = 0
     if (event.keyCode === 39) {
-      delta = 1;
+      delta = 1
+    } else if(event.keyCode === 37) {
+      delta = -1
     }
-    else if(event.keyCode === 37) {
-      delta = -1;
-    }
-    if(delta !== 0) {
+    if (delta !== 0) {
       // We need focus index a separate index variable to achieve circular focus order, otherwise next focus will not go beyond +1/-1 index of active Tab position.
-      this.focusIndex = (this.focusIndex + delta + this.props.tabs.length) % this.props.tabs.length
+      this.focusIndex =
+        (this.focusIndex + delta + this.props.tabs.length) %
+        this.props.tabs.length
       this.tabRefs[this.focusIndex].current.focus()
     }
   }
   render() {
     return (
-      <div className="tabbar" role="tablist" onKeyDown={this.handleKeyDown.bind(this)}>
+      <div
+        className="tabbar"
+        role="tablist"
+        onKeyDown={this.handleKeyDown.bind(this)}
+      >
         <ul>
           {this.props.tabs.map((tab, index) => (
             <li
@@ -90,7 +97,7 @@ export default class TabBar extends React.Component {
                 role="tab"
                 aria-controls={tab.name}
                 aria-selected={this.state.activeTab.index === index}
-                tabindex={this.state.activeTab.index === index ? 0 : -1}
+                tabIndex={this.state.activeTab.index === index ? 0 : -1}
                 ref={this.tabRefs[index]}
               >
                 {tab.name}

--- a/packages/selenium-ide/src/neo/components/TabBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TabBar/index.jsx
@@ -33,7 +33,7 @@ export default class TabBar extends React.Component {
       },
     }
     this.tabRefs = this.props.tabs.map(() => React.createRef())
-    this.forcusIndex = defaultIndex
+    this.focusIndex = defaultIndex
   }
   static propTypes = {
     children: PropTypes.node,
@@ -77,10 +77,9 @@ export default class TabBar extends React.Component {
     return (
       <div
         className="tabbar"
-        role="tablist"
         onKeyDown={this.handleKeyDown.bind(this)}
       >
-        <ul>
+        <ul role="tablist">
           {this.props.tabs.map((tab, index) => (
             <li
               key={tab.name}

--- a/packages/selenium-ide/src/neo/containers/Console/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Console/index.jsx
@@ -89,10 +89,18 @@ export default class Console extends React.Component {
         </TabBar>
         <div className="viewport" ref={this.setViewportRef}>
           {this.state.tab === 'Log' && (
-            <LogList output={output} scrollTo={this.scroll} id="Log" role="tabpanel" />
+            <LogList
+              output={output}
+              scrollTo={this.scroll}
+              id="Log" role="tabpanel"
+            />
           )}
           {this.state.tab === 'Reference' && (
-            <CommandReference currentCommand={command} id="Reference" role="tabpanel" />
+            <CommandReference
+              currentCommand={command}
+              id="Reference"
+              role="tabpanel"
+            />
           )}
         </div>
       </footer>

--- a/packages/selenium-ide/src/neo/containers/Console/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Console/index.jsx
@@ -89,10 +89,10 @@ export default class Console extends React.Component {
         </TabBar>
         <div className="viewport" ref={this.setViewportRef}>
           {this.state.tab === 'Log' && (
-            <LogList output={output} scrollTo={this.scroll} />
+            <LogList output={output} scrollTo={this.scroll} id="Log" role="tabpanel" />
           )}
           {this.state.tab === 'Reference' && (
-            <CommandReference currentCommand={command} />
+            <CommandReference currentCommand={command} id="Reference" role="tabpanel" />
           )}
         </div>
       </footer>

--- a/packages/selenium-ide/src/neo/containers/Console/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Console/index.jsx
@@ -92,7 +92,8 @@ export default class Console extends React.Component {
             <LogList
               output={output}
               scrollTo={this.scroll}
-              id="Log" role="tabpanel"
+              id="Log"
+              role="tabpanel"
             />
           )}
           {this.state.tab === 'Reference' && (


### PR DESCRIPTION
### Description
Added keydown event handler for tab bar which will respond to arrow left/right event to switch focus between tabs which allow People to use keyboard navigation much easier.

### Motivation and Context
Issue: https://github.com/SeleniumHQ/selenium-ide/issues/1185
Keyboard user is not able to access the tab control as tab are accessible through left/right arrow key but it is accessible through TAB key and might not able to use the tab control efficiently if tab control is accessible through TAB key but not through left/right arrow key

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
