### PR TITLE
Improve accessibility for red–green color blindness

### DIFF
--- a/packages/selenium-ide/src/neo/components/Suite/style.css
+++ b/packages/selenium-ide/src/neo/components/Suite/style.css
@@ -1,3 +1,17 @@
+.project .title:before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  text-align: center;
+  font-weight: bold;
+}
+.project > a.passed .title:before{
+  content: '✓';
+}
+.project a.failed .title:before {
+  content: '✗';
+}
+
 .project {
   padding-left: 7px;
   margin-left: 2px;

--- a/packages/selenium-ide/src/neo/components/Test/style.css
+++ b/packages/selenium-ide/src/neo/components/Test/style.css
@@ -1,3 +1,17 @@
+.name span:before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  text-align: center;
+  font-weight: bold;
+}
+.name.passed span:before{
+  content: '✓';
+}
+.name.failed span::before {
+  content: '✗';
+}
+
 .test {
   font-size: 13px;
   line-height: 24px;

--- a/packages/selenium-ide/src/neo/components/TestRow/style.css
+++ b/packages/selenium-ide/src/neo/components/TestRow/style.css
@@ -68,6 +68,21 @@
   color: #e80600;
 }
 
+.test-table tbody tr td.command span:after {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  text-align: center;
+  font-weight: bold;
+}
+.test-table tbody tr.passed td.command span:after {
+  content: '✓';
+}
+.test-table tbody tr.failed td.command span:after,
+.test-table tbody tr.fatal td.command span:after {
+  content: '✗';
+}
+
 .test-table tbody tr td:first-child {
   position: relative;
   flex: initial;

--- a/packages/selenium-ide/src/neo/styles/app.css
+++ b/packages/selenium-ide/src/neo/styles/app.css
@@ -120,11 +120,11 @@ code,
 }
 
 .passed {
-  color: #276533;
+  color: #276533 !important;
 }
 
 .failed {
-  color: #df0006;
+  color: #df0006 !important;
 }
 
 .action-text,


### PR DESCRIPTION
### Description
Add test result of command for red–green color blindness with with ✓ or ✗

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I use Selenium IDE with new students and one of them can't see the result of the tests for each command because he can't distinguish the difference between red and green color.

So I ask him what his the best solution to fix it and here's  a proposal for improvement:

![fix-red–green-color-blindness-01](https://user-images.githubusercontent.com/46624375/107162530-26b6cf80-69a4-11eb-82f1-9258a5eeb430.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

### Version with the improvement
A development version of the extension with the improvement is available here: 
- https://github.com/FrancoisCapon/selenium-ide/releases/tag/v3.17.0.cb