### PR TITLE
Render method declarations similarly to tests

### DIFF
--- a/packages/code-export-csharp-nunit/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-csharp-nunit/__test__/src/__snapshots__/index.spec.js.snap
@@ -179,7 +179,9 @@ public class LoginTest {
     driver.FindElement(By.LinkText(\\"Form Authentication\\")).Click();
     driver.FindElement(By.Id(\\"username\\")).SendKeys(vars[\\"username\\"].ToString());
     driver.FindElement(By.Id(\\"password\\")).SendKeys(vars[\\"password\\"].ToString());
-    driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    if ((Boolean) js.ExecuteScript(\\"return (true)\\")) {
+      driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    }
   }
   [Test]
   public void invalidcredentials() {
@@ -400,7 +402,9 @@ public class ValidcredentialsTest {
     driver.FindElement(By.LinkText(\\"Form Authentication\\")).Click();
     driver.FindElement(By.Id(\\"username\\")).SendKeys(vars[\\"username\\"].ToString());
     driver.FindElement(By.Id(\\"password\\")).SendKeys(vars[\\"password\\"].ToString());
-    driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    if ((Boolean) js.ExecuteScript(\\"return (true)\\")) {
+      driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    }
   }
   [Test]
   public void validcredentials() {

--- a/packages/code-export-csharp-xunit/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-csharp-xunit/__test__/src/__snapshots__/index.spec.js.snap
@@ -180,7 +180,9 @@ public class SuiteTests : IDisposable {
     driver.FindElement(By.LinkText(\\"Form Authentication\\")).Click();
     driver.FindElement(By.Id(\\"username\\")).SendKeys(vars[\\"username\\"].ToString());
     driver.FindElement(By.Id(\\"password\\")).SendKeys(vars[\\"password\\"].ToString());
-    driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    if ((Boolean) js.ExecuteScript(\\"return (true)\\")) {
+      driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    }
   }
   [Fact]
   public void Invalidcredentials() {
@@ -400,7 +402,9 @@ public class SuiteTests : IDisposable {
     driver.FindElement(By.LinkText(\\"Form Authentication\\")).Click();
     driver.FindElement(By.Id(\\"username\\")).SendKeys(vars[\\"username\\"].ToString());
     driver.FindElement(By.Id(\\"password\\")).SendKeys(vars[\\"password\\"].ToString());
-    driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    if ((Boolean) js.ExecuteScript(\\"return (true)\\")) {
+      driver.FindElement(By.CssSelector(\\".fa\\")).Click();
+    }
   }
   [Fact]
   public void Validcredentials() {

--- a/packages/code-export-java-junit/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-java-junit/__test__/src/__snapshots__/index.spec.js.snap
@@ -209,7 +209,9 @@ public class LoginTest {
     driver.findElement(By.linkText(\\"Form Authentication\\")).click();
     driver.findElement(By.id(\\"username\\")).sendKeys(vars.get(\\"username\\").toString());
     driver.findElement(By.id(\\"password\\")).sendKeys(vars.get(\\"password\\").toString());
-    driver.findElement(By.cssSelector(\\".fa\\")).click();
+    if ((Boolean) js.executeScript(\\"return (true)\\")) {
+      driver.findElement(By.cssSelector(\\".fa\\")).click();
+    }
   }
   @Test
   public void invalidcredentials() {
@@ -520,7 +522,9 @@ public class ValidcredentialsTest {
     driver.findElement(By.linkText(\\"Form Authentication\\")).click();
     driver.findElement(By.id(\\"username\\")).sendKeys(vars.get(\\"username\\").toString());
     driver.findElement(By.id(\\"password\\")).sendKeys(vars.get(\\"password\\").toString());
-    driver.findElement(By.cssSelector(\\".fa\\")).click();
+    if ((Boolean) js.executeScript(\\"return (true)\\")) {
+      driver.findElement(By.cssSelector(\\".fa\\")).click();
+    }
   }
   @Test
   public void validcredentials() {

--- a/packages/code-export-javascript-mocha/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-javascript-mocha/__test__/src/__snapshots__/index.spec.js.snap
@@ -132,7 +132,9 @@ describe('login', function() {
     await driver.findElement(By.linkText(\\"Form Authentication\\")).click()
     await driver.findElement(By.id(\\"username\\")).sendKeys(vars[\\"username\\"])
     await driver.findElement(By.id(\\"password\\")).sendKeys(vars[\\"password\\"])
-    await driver.findElement(By.css(\\".fa\\")).click()
+    if (!!await driver.executeScript(\\"return (true)\\")) {
+      await driver.findElement(By.css(\\".fa\\")).click()
+    }
   }
   it('invalid credentials', async function() {
     vars[\\"username\\"] = \\"blah\\"
@@ -285,7 +287,9 @@ describe('valid credentials', function() {
     await driver.findElement(By.linkText(\\"Form Authentication\\")).click()
     await driver.findElement(By.id(\\"username\\")).sendKeys(vars[\\"username\\"])
     await driver.findElement(By.id(\\"password\\")).sendKeys(vars[\\"password\\"])
-    await driver.findElement(By.css(\\".fa\\")).click()
+    if (!!await driver.executeScript(\\"return (true)\\")) {
+      await driver.findElement(By.css(\\".fa\\")).click()
+    }
   }
   it('valid credentials', async function() {
     vars[\\"username\\"] = \\"tomsmith\\"

--- a/packages/code-export-python-pytest/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-python-pytest/__test__/src/__snapshots__/index.spec.js.snap
@@ -140,7 +140,8 @@ class TestLogin():
     self.driver.find_element(By.LINK_TEXT, \\"Form Authentication\\").click()
     self.driver.find_element(By.ID, \\"username\\").send_keys(self.vars[\\"username\\"])
     self.driver.find_element(By.ID, \\"password\\").send_keys(self.vars[\\"password\\"])
-    self.driver.find_element(By.CSS_SELECTOR, \\".fa\\").click()
+    if self.driver.execute_script(\\"return (true)\\"):
+      self.driver.find_element(By.CSS_SELECTOR, \\".fa\\").click()
   
   def test_invalidcredentials(self):
     self.vars[\\"username\\"] = \\"blah\\"
@@ -305,7 +306,8 @@ class TestValidcredentials():
     self.driver.find_element(By.LINK_TEXT, \\"Form Authentication\\").click()
     self.driver.find_element(By.ID, \\"username\\").send_keys(self.vars[\\"username\\"])
     self.driver.find_element(By.ID, \\"password\\").send_keys(self.vars[\\"password\\"])
-    self.driver.find_element(By.CSS_SELECTOR, \\".fa\\").click()
+    if self.driver.execute_script(\\"return (true)\\"):
+      self.driver.find_element(By.CSS_SELECTOR, \\".fa\\").click()
   
   def test_validcredentials(self):
     self.vars[\\"username\\"] = \\"tomsmith\\"

--- a/packages/code-export-ruby-rspec/__test__/src/__snapshots__/index.spec.js.snap
+++ b/packages/code-export-ruby-rspec/__test__/src/__snapshots__/index.spec.js.snap
@@ -120,7 +120,9 @@ describe 'Login' do
     @driver.find_element(:link_text, 'Form Authentication').click
     @driver.find_element(:id, 'username').send_keys(@vars['username'])
     @driver.find_element(:id, 'password').send_keys(@vars['password'])
-    @driver.find_element(:css, '.fa').click
+    if @driver.execute_script(\\"return (true)\\")
+      @driver.find_element(:css, '.fa').click
+    end
   end
   it 'invalidcredentials' do
     @vars['username'] = 'blah'
@@ -275,7 +277,9 @@ describe 'Validcredentials' do
     @driver.find_element(:link_text, 'Form Authentication').click
     @driver.find_element(:id, 'username').send_keys(@vars['username'])
     @driver.find_element(:id, 'password').send_keys(@vars['password'])
-    @driver.find_element(:css, '.fa').click
+    if @driver.execute_script(\\"return (true)\\")
+      @driver.find_element(:css, '.fa').click
+    end
   end
   it 'validcredentials' do
     @vars['username'] = 'tomsmith'

--- a/packages/side-utils/__test__/test-files/test-case-reuse.side
+++ b/packages/side-utils/__test__/test-files/test-case-reuse.side
@@ -57,6 +57,13 @@
       ],
       "value": "${password}"
     }, {
+      "id": "0ac586f1-37a8-4059-9e67-241da62f8905",
+      "comment": "",
+      "command": "if",
+      "target": "true",
+      "targets": [],
+      "value": ""
+    }, {
       "id": "8081fd74-50b1-4f5c-95f1-c171519b8700",
       "comment": "",
       "command": "click",
@@ -67,6 +74,13 @@
         ["xpath=//i", "xpath:position"],
         ["xpath=//i[contains(.,' Login')]", "xpath:innerText"]
       ],
+      "value": ""
+    }, {
+      "id": "ca185097-14b4-4bd1-bdad-380a71bb067b",
+      "comment": "",
+      "command": "end",
+      "target": "",
+      "targets": [],
       "value": ""
     }]
   }, {

--- a/packages/side-utils/src/code-export/emit.js
+++ b/packages/side-utils/src/code-export/emit.js
@@ -152,8 +152,9 @@ async function emitMethod(
       newLineCount: 0,
       startingLevel: level,
     })
-    // Remove any trailing newlines on result to avoid double newlines
-    // when the array gets converted to a string
+    // Remove any trailing newlines on result to avoid double newlines.
+    // Newlines get added when the final array elements are combined,
+    // so any trailing newlines result in awkward empty lines.
     if (result.slice(-1) === '\n') {
       result = result.slice(0, -1)
     }

--- a/packages/side-utils/src/code-export/emit.js
+++ b/packages/side-utils/src/code-export/emit.js
@@ -127,8 +127,10 @@ async function emitMethod(
   {
     commandPrefixPadding,
     generateMethodDeclaration,
+    level,
     terminatingKeyword,
     emitter,
+    render,
     overrideCommandEmitting,
   } = {}
 ) {
@@ -141,17 +143,16 @@ async function emitMethod(
   }
   let result
   if (overrideCommandEmitting) {
-    result = method.commands.map(
-      cmd => `${commandPrefixPadding.repeat(cmd.level) + cmd.statement}`
-    )
+    result = method.commands
+      .map(cmd => `${commandPrefixPadding.repeat(cmd.level) + cmd.statement}`)
+      .join(`\n${commandPrefixPadding}`)
+      .replace(/^/, commandPrefixPadding)
   } else {
-    result = await emitCommands(method.commands, emitter)
+    result = render(await emitCommands(method.commands, emitter), {
+      startingLevel: level,
+    })
   }
-  return [
-    _methodDeclaration,
-    result.join(`\n${commandPrefixPadding}`).replace(/^/, commandPrefixPadding),
-    _terminatingKeyword,
-  ]
+  return [_methodDeclaration, result, _terminatingKeyword]
 }
 
 export function emitOriginTracing(
@@ -235,6 +236,8 @@ async function emitTest(
           emitter,
           commandPrefixPadding,
           generateMethodDeclaration: method.generateMethodDeclaration,
+          level: testLevel,
+          render,
           terminatingKeyword,
           overrideCommandEmitting: true,
         })
@@ -252,6 +255,8 @@ async function emitTest(
       emitter,
       commandPrefixPadding,
       generateMethodDeclaration,
+      level: testLevel,
+      render,
       terminatingKeyword,
     })
     await registerMethod(method.name, result, {

--- a/packages/side-utils/src/code-export/emit.js
+++ b/packages/side-utils/src/code-export/emit.js
@@ -149,8 +149,14 @@ async function emitMethod(
       .replace(/^/, commandPrefixPadding)
   } else {
     result = render(await emitCommands(method.commands, emitter), {
+      newLineCount: 0,
       startingLevel: level,
     })
+    // Remove any trailing newlines on result to avoid double newlines
+    // when the array gets converted to a string
+    if (result.slice(-1) === '\n') {
+      result = result.slice(0, -1)
+    }
   }
   return [_methodDeclaration, result, _terminatingKeyword]
 }

--- a/packages/side-utils/src/code-export/render.js
+++ b/packages/side-utils/src/code-export/render.js
@@ -21,16 +21,13 @@ export default function render(
   commandPrefixPadding,
   input,
   {
-    startingLevel,
-    newLineCount,
-    fullPayload,
+    startingLevel = 0,
+    newLineCount = 1,
+    fullPayload = false,
     originTracing,
     enableOriginTracing,
   } = {}
 ) {
-  if (!startingLevel) startingLevel = 0
-  if (!newLineCount) newLineCount = 1
-  if (!fullPayload) fullPayload = false
   if (Array.isArray(input)) {
     // e.g., an array of emitted command strings to be stitched together
     return renderCommands(input, {


### PR DESCRIPTION
### Description

This makes method body generation work more similarly to test generation.

Rather than using a one-off method to generate our method declarations, we take in the render and testLevel variables from emitTests, and use these to generate our method declarations.  

### Motivation and Context

The way it previously worked, command emitters that used any syntax other than raw strings would render as [Object object] within method declarations.
Standard emitters like this wouldn't work:

```
click: async function emitClick() {
  return promise.resolve({ commands: [{ statement: 'xyz.click()' level: 0 }] })
}
```

This meant that re-using tests as methods required some pretty heavy changes to the previously written export format.
Additionally, this meant that commands that affected indentation in methods, like control flow blocks, would generally fail to render correctly due to their usage of staringLevelAdjustment and endingLevelAdjustment.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
