### PR TITLE
[docs] Add link to edge extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We are using [SideeX](http://sideex.org/) as a start point. The SideeX team was 
 ### Pre-packaged
 - [Chrome extension](https://chrome.google.com/webstore/detail/selenium-ide/mooikfkahbdckldjjndioackbalphokd)
 - [Firefox extension](https://addons.mozilla.org/en-GB/firefox/addon/selenium-ide/)
+- [Edge extension](https://microsoftedge.microsoft.com/addons/detail/selenium-ide/ajdpfmkffanmkhejnopjppegokpogffp)
 
 ## Prerequisites
 


### PR DESCRIPTION
Just adds a link to the selenium-ide extension in the IE edge store.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
