### PR TITLE
Allow single command export via code-export

### DIFF
--- a/packages/code-export-csharp-nunit/__test__/src/index.spec.js
+++ b/packages/code-export-csharp-nunit/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export C# NUnit', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-csharp-nunit/src/index.js
+++ b/packages/code-export-csharp-nunit/src/index.js
@@ -122,6 +122,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-csharp-xunit/__test__/src/index.spec.js
+++ b/packages/code-export-csharp-xunit/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export C# xUnit', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-csharp-xunit/src/index.js
+++ b/packages/code-export-csharp-xunit/src/index.js
@@ -164,6 +164,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-java-junit/__test__/src/index.spec.js
+++ b/packages/code-export-java-junit/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export Java JUnit', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-java-junit/src/index.js
+++ b/packages/code-export-java-junit/src/index.js
@@ -122,6 +122,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-javascript-mocha/__test__/src/index.spec.js
+++ b/packages/code-export-javascript-mocha/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export JavaScript Mocha', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-javascript-mocha/src/index.js
+++ b/packages/code-export-javascript-mocha/src/index.js
@@ -122,6 +122,7 @@ export default {
   emit: {
     test: emitTest,
     suite: emitSuite,
+    command: emitter.emit,
     locator: location.emit,
   },
   register: {

--- a/packages/code-export-python-pytest/__test__/src/index.spec.js
+++ b/packages/code-export-python-pytest/__test__/src/index.spec.js
@@ -139,7 +139,7 @@ describe('Code Export Python pytest', () => {
     expect(results.body).toMatchSnapshot()
   })
   it('should export the command emitter', () => {
-    expect(Command.emit).toStrictEqual(codeExport.emit.command.apply)
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-python-pytest/__test__/src/index.spec.js
+++ b/packages/code-export-python-pytest/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export Python pytest', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command.apply)
   })
 })
 

--- a/packages/code-export-python-pytest/src/index.js
+++ b/packages/code-export-python-pytest/src/index.js
@@ -124,6 +124,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export-ruby-rspec/__test__/src/index.spec.js
+++ b/packages/code-export-ruby-rspec/__test__/src/index.spec.js
@@ -17,7 +17,13 @@
 
 import fs from 'fs'
 import path from 'path'
-import { emitTest, emitSuite, _emitMethod, _findTestByName } from '../../src'
+import codeExport, {
+  emitTest,
+  emitSuite,
+  _emitMethod,
+  _findTestByName,
+} from '../../src'
+import Command from '../../src/command'
 import { project as projectProcessor } from '@seleniumhq/side-utils'
 
 function readFile(filename) {
@@ -131,6 +137,9 @@ describe('Code Export Ruby RSpec', () => {
     })
     expect(results.body).toBeDefined()
     expect(results.body).toMatchSnapshot()
+  })
+  it('should export the command emitter', () => {
+    expect(Command.emit).toStrictEqual(codeExport.emit.command)
   })
 })
 

--- a/packages/code-export-ruby-rspec/src/index.js
+++ b/packages/code-export-ruby-rspec/src/index.js
@@ -124,6 +124,7 @@ export default {
     test: emitTest,
     suite: emitSuite,
     locator: location.emit,
+    command: emitter.emit,
   },
   register: {
     command: emitter.register,

--- a/packages/code-export/__test__/src/index.spec.js
+++ b/packages/code-export/__test__/src/index.spec.js
@@ -1,0 +1,14 @@
+import { emitCommand } from '../../src'
+
+describe('Code Export Python pytest', () => {
+  it('should export a test', async () => {
+    let x = await emitCommand('python-pytest', {
+      command: 'click',
+      target: "//form[input/@name='email']",
+      value: '',
+    })
+    expect(x).toEqual(
+      'self.driver.find_element(By.XPATH, "//form[input/@name=\\\'email\\\']").click()'
+    )
+  })
+})

--- a/packages/code-export/__test__/src/index.spec.js
+++ b/packages/code-export/__test__/src/index.spec.js
@@ -2,12 +2,12 @@ import { emitCommand } from '../../src'
 
 describe('Code Export Python pytest', () => {
   it('should export a test', async () => {
-    let x = await emitCommand('python-pytest', {
+    let command = await emitCommand('python-pytest', {
       command: 'click',
       target: "//form[input/@name='email']",
       value: '',
     })
-    expect(x).toEqual(
+    expect(command).toEqual(
       'self.driver.find_element(By.XPATH, "//form[input/@name=\\\'email\\\']").click()'
     )
   })

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -107,7 +107,6 @@ export function emitSuite(
 }
 
 export function emitCommand(language, { command, target, value }) {
-  console.log(availableLanguages[language].default)
   return availableLanguages[language].default.emit.command({
     command,
     target,

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -110,7 +110,7 @@ export function emitCommand(language, { command, target, value }) {
   return availableLanguages[language].default.emit.command({
     command,
     target,
-    value
+    value,
   })
 }
 

--- a/packages/code-export/src/index.js
+++ b/packages/code-export/src/index.js
@@ -106,6 +106,15 @@ export function emitSuite(
   })
 }
 
+export function emitCommand(language, { command, target, value }) {
+  console.log(availableLanguages[language].default)
+  return availableLanguages[language].default.emit.command({
+    command,
+    target,
+    value
+  })
+}
+
 export function emitLocator(language, input) {
   return availableLanguages[language].default.emit.locator(input)
 }
@@ -125,6 +134,7 @@ export default {
   emit: {
     test: emitTest,
     suite: emitSuite,
+    command: emitCommand,
     locator: emitLocator,
   },
 }


### PR DESCRIPTION
<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->

**Thanks for contributing to the Selenium IDE!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
As described in #1254: It would be useful to have emitCommand available in the export-code API. This function should generate the command with given target / value for a selected language / test framework.

### Motivation and Context
We wish to export commands on a per-command basis.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
