### PR TITLE
Save and quit, allow for cancellation

### DIFF
--- a/packages/selenium-ide/src/api/commands/projects/load.ts
+++ b/packages/selenium-ide/src/api/commands/projects/load.ts
@@ -14,6 +14,9 @@ const defaultSuite: Partial<SuiteShape> = {
   tests: [loadingID],
 }
 export const mutator: Mutator<Shape> = (session, { result }) => {
+  if (!result) {
+    return session
+  }
   const firstSuite = result.suites?.[0] ?? defaultSuite
   const activeSuiteID = firstSuite.id
   const activeTestID = firstSuite.tests[0] ?? loadingID

--- a/packages/selenium-ide/src/api/commands/system/index.ts
+++ b/packages/selenium-ide/src/api/commands/system/index.ts
@@ -1,1 +1,2 @@
 export * as crash from './crash'
+export * as quit from './quit'

--- a/packages/selenium-ide/src/api/commands/system/quit.ts
+++ b/packages/selenium-ide/src/api/commands/system/quit.ts
@@ -1,0 +1,8 @@
+import browserHandler from 'browser/api/classes/Handler'
+import mainHandler from 'main/api/classes/Handler'
+
+export type Shape = (error: unknown) => Promise<void> 
+
+export const browser = browserHandler<Shape>()
+
+export const main = mainHandler<Shape>()

--- a/packages/selenium-ide/src/main/session/controllers/Dialogs/index.ts
+++ b/packages/selenium-ide/src/main/session/controllers/Dialogs/index.ts
@@ -25,14 +25,4 @@ export default class DialogsController {
   async openSave() {
     return await dialog.showSaveDialog({})
   }
-  // async promptSave(
-  //   options: Electron.MessageBoxOptions = {
-  //     message: 'Save changes to current project?',
-  //     buttons: ['Yes', 'No'],
-  //   }
-  // ): Promise<boolean> {
-  //   const { response } = await dialog.showMessageBox(options)
-  //   const confirmed = response === 0
-  //   return confirmed
-  // }
 }

--- a/packages/selenium-ide/src/main/session/controllers/Menu/menus/application.ts
+++ b/packages/selenium-ide/src/main/session/controllers/Menu/menus/application.ts
@@ -18,7 +18,13 @@ const applicationMenu = (session: Session) => async () =>
         { role: 'hideOthers' },
         { role: 'unhide' },
         { type: 'separator' },
-        { role: 'quit' },
+        {
+          accelerator: 'CommandOrControl+Q',
+          label: 'Quit',
+          click: async () => {
+            await session.system.quit()
+          },
+        },
       ],
     },
     {

--- a/packages/selenium-ide/src/main/session/controllers/System/index.ts
+++ b/packages/selenium-ide/src/main/session/controllers/System/index.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron'
+import { dialog } from 'electron'
 import { Session } from 'main/types'
 
 
@@ -18,7 +18,13 @@ export default class SystemController {
       message: error,
       type: "error"
     })
-    app.quit()
+    this.quit()
+  }
+  async quit() {
+    const confirm = await this.session.projects.checkIfCurrentProjectChanged()
+    if (confirm) {
+      this.session.app.quit()
+    }
   }
   session: Session
 }


### PR DESCRIPTION
Exposes a boolean within checkIfCurrentProjectChanged

If truthy, continue the action.
If falsy, abort.

Make load optionally handle null as its result shape instead of a new project
Expose quit as a manually instrumented menu function

Delete a commented out function