### PR TITLE
Feat: playback stabilizations

### DIFF
--- a/packages/selenium-ide/src/main/session/controllers/Driver/index.ts
+++ b/packages/selenium-ide/src/main/session/controllers/Driver/index.ts
@@ -1,6 +1,5 @@
 // import { Chrome } from '@seleniumhq/browser-info'
 import { WebDriverExecutor } from '@seleniumhq/side-runtime'
-import { WebDriverExecutorHooks } from '@seleniumhq/side-runtime/src/webdriver'
 import { ChildProcess } from 'child_process'
 import { BrowserInfo, Session } from 'main/types'
 import downloadDriver from './download'
@@ -60,7 +59,7 @@ export default class DriverController {
       },
       customCommands: this.session.commands.customCommands,
       hooks: {
-        onBeforePlay: this.onBeforePlay.bind(this),
+        onBeforePlay: (v) => this.session.playback.onBeforePlay(v),
       },
       server,
       windowAPI: {
@@ -77,32 +76,6 @@ export default class DriverController {
       },
     })
     return driver
-  }
-
-  onBeforePlay: NonNullable<WebDriverExecutorHooks['onBeforePlay']> = async ({
-    driver: executor,
-  }) => {
-    const { state, windows } = this.session
-    const sessionData = await state.get()
-    if (sessionData.state.playback.currentIndex === -1) {
-      await windows.initializePlaybackWindow()
-    }
-    const playbackWindow = await windows.getPlaybackWindow()
-
-    const { driver } = executor
-    // Figure out playback window from document.title
-    const handles = await driver.getAllWindowHandles()
-    for (let i = 0, ii = handles.length; i !== ii; i++) {
-      await driver.switchTo().window(handles[i])
-      const title = await driver.getTitle()
-      const url = await driver.getCurrentUrl()
-      if (
-        title === playbackWindow.getTitle() &&
-        url === playbackWindow.webContents.getURL()
-      ) {
-        break
-      }
-    }
   }
 
   async download(info: BrowserInfo) {

--- a/packages/selenium-ide/src/main/session/controllers/Menu/menus/testEditor.ts
+++ b/packages/selenium-ide/src/main/session/controllers/Menu/menus/testEditor.ts
@@ -100,8 +100,9 @@ export const recorderList = (session: Session) => async () => {
   ]
 }
 
-export const playbackList: MenuComponent = (session) => async () => {
+export const playbackList: MenuComponent = (session) => async (_commandID?: string) => {
   const sessionData = await session.state.get()
+  const commandID = _commandID || sessionData.state.activeCommandID
   const editorState = sessionData.state.editor
   const selectedCommandCount = editorState.selectedCommandIndexes.length
   return [
@@ -111,7 +112,7 @@ export const playbackList: MenuComponent = (session) => async () => {
         await session.api.playback.play(sessionData.state.activeTestID, [
           0,
           activeTest.commands.findIndex(
-            (cmd) => cmd.id === sessionData.state.activeCommandID
+            (cmd) => cmd.id === commandID
           ),
         ])
       },
@@ -124,7 +125,7 @@ export const playbackList: MenuComponent = (session) => async () => {
         const activeTest = getActiveTest(sessionData)
         await session.api.playback.play(sessionData.state.activeTestID, [
           activeTest.commands.findIndex(
-            (cmd) => cmd.id === sessionData.state.activeCommandID
+            (cmd) => cmd.id === commandID
           ),
           activeTest.commands.length - 1,
         ])
@@ -137,7 +138,7 @@ export const playbackList: MenuComponent = (session) => async () => {
         const activeTest = getActiveTest(sessionData)
         await session.api.playback.play(sessionData.state.activeTestID, [
           activeTest.commands.findIndex(
-            (cmd) => cmd.id === sessionData.state.activeCommandID
+            (cmd) => cmd.id === commandID
           ),
           activeTest.commands.length - 1,
         ])

--- a/packages/side-runtime/src/playback.ts
+++ b/packages/side-runtime/src/playback.ts
@@ -481,7 +481,7 @@ export default class Playback {
         state: result.skipped ? CommandStates.SKIPPED : CommandStates.PASSED,
         message: undefined,
       })
-      this.currentExecutingNode = result.next
+      this.currentExecutingNode = result.next as CommandNode
 
       return await this._executionLoop()
     }
@@ -540,6 +540,7 @@ export default class Playback {
         ? result
         : {
             next: (this.playbackTree as PlaybackTree).startingCommandNode,
+            skipped: false,
           }
     } else {
       const result = await commandNode.execute(this.executor)

--- a/packages/side-runtime/src/webdriver.ts
+++ b/packages/side-runtime/src/webdriver.ts
@@ -420,26 +420,12 @@ export default class WebDriverExecutor {
     _: string,
     commandObject: Partial<CommandShape> = {}
   ) {
+    // This technically uses double the implicitWait but o well darn
     const element = await this.waitForElement(locator, commandObject.targets)
-    let finalTime = Date.now() + this.implicitWait
-    let success = null
-    while (!success && finalTime > Date.now()) {
-      try {
-        await element.click()
-        success = true
-      } catch (e) {
-        console.warn('Click encountered a webdriver failure:')
-        console.error(e)
-        if (finalTime > Date.now()) {
-          console.info('Retrying...')
-        }
-      }
-    }
-    if (!success) {
-      throw new Error(
-        `Failed to click element at ${locator} within ${this.implicitWait}ms`
-      )
-    }
+
+    const timeout = Date.now() + this.implicitWait
+    await this.wait(until.elementIsVisible(element), timeout - Date.now())
+    await element.click()
   }
 
   async doClickAt(


### PR DESCRIPTION
Make playback smoothly handle missing windows
Moved onBeforePlay out of driver and into playback
Made some types in side-runtime a bit more consistent
Move retry logic out of onClick event and into CommandNode.execute