### PR TITLE
handle portional playback correctly

### DIFF
--- a/packages/selenium-ide/src/main/session/controllers/Menu/menus/testEditor.ts
+++ b/packages/selenium-ide/src/main/session/controllers/Menu/menus/testEditor.ts
@@ -1,3 +1,4 @@
+import { hasID } from '@seleniumhq/side-api'
 import {
   getActiveCommand,
   getActiveCommandIndex,
@@ -127,7 +128,7 @@ export const playbackList: MenuComponent =
           const activeTest = getActiveTest(sessionData)
           await session.api.playback.play(sessionData.state.activeTestID, [
             activeTest.commands.findIndex((cmd) => cmd.id === commandID),
-            activeTest.commands.length - 1,
+            -1,
           ])
         },
         enabled: selectedCommandCount === 1,
@@ -136,9 +137,10 @@ export const playbackList: MenuComponent =
       {
         click: async () => {
           const activeTest = getActiveTest(sessionData)
+          const index = activeTest.commands.findIndex(hasID(commandID))
           await session.api.playback.play(sessionData.state.activeTestID, [
-            activeTest.commands.findIndex((cmd) => cmd.id === commandID),
-            activeTest.commands.length - 1,
+            index,
+            index,
           ])
         },
         enabled: selectedCommandCount === 1,

--- a/packages/side-api/src/commands/playback/play.ts
+++ b/packages/side-api/src/commands/playback/play.ts
@@ -1,4 +1,3 @@
-import set from 'lodash/fp/set'
 import { defaultPlaybackState } from '../../models'
 import { Mutator } from '../../types'
 
@@ -11,9 +10,16 @@ export type Shape = (
   playRange?: [number, number]
 ) => Promise<void>
 
-export const mutator: Mutator = (session) =>
-  set(
-    'state.playback',
-    defaultPlaybackState,
-    set('state.status', 'playing', session)
-  )
+export const mutator: Mutator<Shape> = (
+  session,
+  { params: [_testID, playRange = [0, -1]] }
+) => ({
+  ...session,
+  state: {
+    ...session.state,
+    playback:
+      playRange[0] === 0 ? defaultPlaybackState : session.state.playback,
+    status: 'playing',
+    stopIndex: playRange[1],
+  },
+})

--- a/packages/side-runtime/src/playback.ts
+++ b/packages/side-runtime/src/playback.ts
@@ -254,9 +254,9 @@ export default class Playback {
       await this.executor.cancel()
     }
     this[state].isPlaying = false
-    // await new Promise((res) => {
-    //   this[state].pausingResolve = res
-    // })
+    await new Promise((res) => {
+      this[state].pausingResolve = res
+    })
   }
 
   resume() {
@@ -386,13 +386,14 @@ export default class Playback {
         message: undefined,
       })
 
+      const steps = this[state].steps
       if (this[state].stopping) {
         return
       } else if (this[state].pausing) {
         await this._pause()
         return await this._executionLoop({ ignoreBreakpoint: true })
-      } else if (this[state].steps !== undefined) {
-        if (this[state].steps === 0) {
+      } else if (steps !== undefined) {
+        if (steps === 0) {
           this[state].steps = undefined
           const stepPromise = this[state].stepPromise
           if (stepPromise) {
@@ -401,8 +402,7 @@ export default class Playback {
           await this._pause()
           return await this._executionLoop({ ignoreBreakpoint: true })
         }
-        // @ts-expect-error
-        this[state].steps--
+        this[state].steps = steps - 1
       }
 
       const playTo = this[state].playTo
@@ -641,6 +641,7 @@ export default class Playback {
       playTo?.command &&
       this.currentExecutingNode?.command.id === playTo.command
     ) {
+      this[state].isPlaying = false
       playTo.res()
     }
 


### PR DESCRIPTION
@coinzdude - Check it out! The important line was really here:

packages/side-runtime/src/playback.ts
L644

By making it so that if the playRange ends, we mark isPlaying as false, it lets us chain things together. Also, playSingleCommand is fixed, and I wanted the variable handling to only reset when a test completes or on session start, so that way piecemeal plays keep variables intact and such.

Lemme know what you think!