### PR TITLE
User pref to ignore SSL errors

### DIFF
--- a/packages/selenium-ide/.vscode/launch.json
+++ b/packages/selenium-ide/.vscode/launch.json
@@ -53,7 +53,7 @@
       "request": "attach",
       "port": 8315, //use debug port opened in Electron: Main configuration
       "webRoot": "${workspaceFolder}",
-      "timeout": 30000
+      "timeout": 90000
     }
   ],
   "compounds": [ //launch multiple configurations concurrently

--- a/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Project/ProjectTab.tsx
+++ b/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Project/ProjectTab.tsx
@@ -112,6 +112,25 @@ const ProjectTab: FC<ProjectTabProps> = ({ session: { project, state } }) => (
             <MenuItem value="No">No</MenuItem>
           </Select>
         </FormControl>
+        <FormControl>
+          <InputLabel id="ignoreSSLErrors">
+            Ignore Certificate/SSL errors
+          </InputLabel>
+          <Select
+            id="ignoreCertificateErrorsPref"
+            label="Ignore Certificate/SSL errors"
+            name="ignoreCertificateErrorsPref"
+            value={state.userPrefs.ignoreCertificateErrorsPref}
+            onChange={(e: any) => {
+              window.sideAPI.state.toggleUserPrefIgnoreCertificateErrors(
+                e.target.value
+              )
+            }}
+          >
+            <MenuItem value="Yes">Yes</MenuItem>
+            <MenuItem value="No">No</MenuItem>
+          </Select>
+        </FormControl>
       </Stack>
       <List
         dense

--- a/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Project/ProjectTab.tsx
+++ b/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Project/ProjectTab.tsx
@@ -118,7 +118,7 @@ const ProjectTab: FC<ProjectTabProps> = ({ session: { project, state } }) => (
           </InputLabel>
           <Select
             id="ignoreCertificateErrorsPref"
-            label="Ignore Certificate/SSL errors"
+            label="Ignore Certificate/SSL errors - Please be aware of the risks of ignoring SSL errors"
             name="ignoreCertificateErrorsPref"
             value={state.userPrefs.ignoreCertificateErrorsPref}
             onChange={(e: any) => {

--- a/packages/selenium-ide/src/main/index.ts
+++ b/packages/selenium-ide/src/main/index.ts
@@ -22,6 +22,7 @@ process.on('uncaughtException', (error) => {
 
 // Instantiate the session
 const session = createSession(app, store)
+
 app.on('open-file', async (_e, path) => {
   await session.projects.load(path)
 })
@@ -57,3 +58,18 @@ app.on('window-all-closed', async () => {
     await session.system.quit()
   }
 })
+
+app.on(
+  'certificate-error',
+  (event, _webContents, _url, _error, _certificate, callback) => {
+    session.state.getUserPrefs().then((userPrefs) => {
+      console.log(userPrefs)
+      if (userPrefs.ignoreCertificateErrorsPref === 'Yes') {
+        event.preventDefault()
+        callback(true)
+      }
+      else
+        callback(false)
+    })
+  }
+)

--- a/packages/selenium-ide/src/main/index.ts
+++ b/packages/selenium-ide/src/main/index.ts
@@ -64,12 +64,13 @@ app.on(
   (event, _webContents, _url, _error, _certificate, callback) => {
     session.state.getUserPrefs().then((userPrefs) => {
       console.log(userPrefs)
-      if (userPrefs.ignoreCertificateErrorsPref === 'Yes') {
+      if (
+        userPrefs.ignoreCertificateErrorsPref === 'Yes' &&
+        _url.startsWith(session.projects.project.url)
+      ) {
         event.preventDefault()
         callback(true)
-      }
-      else
-        callback(false)
+      } else callback(false)
     })
   }
 )

--- a/packages/selenium-ide/src/main/session/controllers/State/index.ts
+++ b/packages/selenium-ide/src/main/session/controllers/State/index.ts
@@ -1,8 +1,10 @@
 import { getCommandIndex } from '@seleniumhq/side-api/dist/helpers/getActiveData'
-import { state as defaultState, defaultUserPrefs } from '@seleniumhq/side-api'
+import { state as defaultState } from '@seleniumhq/side-api'
 import {
   CamelCaseNamesPref,
   CoreSessionData,
+  defaultUserPrefs,
+  IgnoreCertificateErrorsPref,
   InsertCommandPref,
   StateShape,
   ThemePref,
@@ -83,6 +85,14 @@ export default class StateController extends BaseController {
       defaultUserPrefs
     )
     storage.set<'userPrefs'>('userPrefs', { ...userPrefs, insertCommandPref })
+  }
+
+  async toggleUserPrefIgnoreCertificateErrors(ignoreCertificateErrorsPref: IgnoreCertificateErrorsPref) {
+    const userPrefs = await storage.get<'userPrefs'>(
+      'userPrefs',
+      defaultUserPrefs
+    )
+    storage.set<'userPrefs'>('userPrefs', { ... userPrefs, ignoreCertificateErrorsPref})
   }
 
   async getUserPrefs(): Promise<UserPrefs> {

--- a/packages/side-api/src/commands/state/index.ts
+++ b/packages/side-api/src/commands/state/index.ts
@@ -10,6 +10,7 @@ import type { Shape as SetCopiedCommands } from './setCopiedCommands'
 import type { Shape as ToggleBreakpoint } from './toggleBreakpoint'
 import type { Shape as ToggleSuiteMode } from './toggleSuiteMode'
 import type { Shape as ToggleUserPrefCamelCase } from './toggleUserPrefCamelCase'
+import type { Shape as ToggleUserPrefIgnoreCertificateErrors } from './toggleUserPrefIgnoreCertificateErrors'
 import type { Shape as ToggleUserPrefInsert } from './toggleUserPrefInsert'
 import type { Shape as ToggleUserPrefTheme } from './toggleUserPrefTheme'
 import type { Shape as UpdateStepSelection } from './updateStepSelection'
@@ -27,6 +28,7 @@ import * as setCopiedCommands from './setCopiedCommands'
 import * as toggleBreakpoint from './toggleBreakpoint'
 import * as toggleSuiteMode from './toggleSuiteMode'
 import * as toggleUserPrefCamelCase from './toggleUserPrefCamelCase'
+import * as toggleUserPrefIgnoreCertificateErrors from './toggleUserPrefIgnoreCertificateErrors'
 import * as toggleUserPrefInsert from './toggleUserPrefInsert'
 import * as toggleUserPrefTheme from './toggleUserPrefTheme'
 import * as updateStepSelection from './updateStepSelection'
@@ -45,6 +47,7 @@ export const commands = {
   toggleBreakpoint,
   toggleSuiteMode,
   toggleUserPrefCamelCase,
+  toggleUserPrefIgnoreCertificateErrors,
   toggleUserPrefInsert,
   toggleUserPrefTheme,
   updateStepSelection,
@@ -67,6 +70,7 @@ export type Shape = {
   toggleBreakpoint: ToggleBreakpoint
   toggleSuiteMode: ToggleSuiteMode
   toggleUserPrefCamelCase: ToggleUserPrefCamelCase
+  toggleUserPrefIgnoreCertificateErrors: ToggleUserPrefIgnoreCertificateErrors
   toggleUserPrefInsert: ToggleUserPrefInsert
   toggleUserPrefTheme: ToggleUserPrefTheme
   updateStepSelection: UpdateStepSelection

--- a/packages/side-api/src/commands/state/toggleUserPrefIgnoreCertificateErrors.ts
+++ b/packages/side-api/src/commands/state/toggleUserPrefIgnoreCertificateErrors.ts
@@ -1,0 +1,21 @@
+import set from 'lodash/fp/set'
+import { IgnoreCertificateErrorsPref } from '../../models/state'
+import { Mutator } from '../../types'
+
+/**
+ * Customizes command insert behavior to either follow or lead the current
+ * command
+ */
+export type Shape = (
+  ignoreCertificateErrorsPref: IgnoreCertificateErrorsPref
+) => Promise<void>
+
+export const mutator: Mutator<Shape> = (
+  session,
+  { params: [ignoreCertificateErrorsPref] }
+) =>
+  set(
+    'state.userPrefs.ignoreCertificateErrorsPref',
+    ignoreCertificateErrorsPref,
+    session
+  )

--- a/packages/side-api/src/models/state/index.ts
+++ b/packages/side-api/src/models/state/index.ts
@@ -34,17 +34,20 @@ export const defaultRecorderState: RecorderStateShape = {
 export type InsertCommandPref = 'Before' | 'After'
 export type ThemePref = 'Dark' | 'Light' | 'System'
 export type CamelCaseNamesPref = 'Yes' | 'No'
+export type IgnoreCertificateErrorsPref = 'Yes' | 'No'
 
 export interface UserPrefs {
   insertCommandPref: InsertCommandPref
   themePref: ThemePref
   camelCaseNamesPref: CamelCaseNamesPref
+  ignoreCertificateErrorsPref: IgnoreCertificateErrorsPref
 }
 
 export const defaultUserPrefs: UserPrefs = {
   insertCommandPref: 'After',
   themePref: 'System',
   camelCaseNamesPref: 'No',
+  ignoreCertificateErrorsPref: 'No',
 }
 
 export interface PlaybackStateShape {


### PR DESCRIPTION
script developers may need to ignore SSL errors, e.g. when developing against some local instance, or explicitly not ignore SSL errors, e.g. production validation.

This gives the user the choice.