### PR TITLE
fix:waitForNewWindow with timeout

### DIFF
--- a/packages/selenium-ide/package.json
+++ b/packages/selenium-ide/package.json
@@ -110,7 +110,7 @@
     "@seleniumhq/side-api": "^4.0.0-alpha.16",
     "@seleniumhq/side-model": "^4.0.0-alpha.2",
     "@seleniumhq/side-plugin-example": "^4.0.0-alpha.1",
-    "@seleniumhq/side-runtime": "^4.0.0-alpha.16",
+    "@seleniumhq/side-runtime": "^4.0.0-alpha.17",
     "dnd-core": "16.0.1",
     "electron-chromedriver": "^18.0.0",
     "electron-log": "^4.4.8",

--- a/packages/side-runner/package.json
+++ b/packages/side-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selenium-side-runner",
-  "version": "4.0.0-alpha.34",
+  "version": "4.0.0-alpha.35",
   "description": "Run Selenium IDE projects in cli",
   "repository": "https://github.com/SeleniumHQ/selenium-ide",
   "scripts": {
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@seleniumhq/side-model": "^4.0.0-alpha.2",
-    "@seleniumhq/side-runtime": "^4.0.0-alpha.15",
+    "@seleniumhq/side-runtime": "^4.0.0-alpha.17",
     "commander": "^9.4.0",
     "glob": "^7.2.0",
     "jest": "^27.5.1",

--- a/packages/side-runtime/package.json
+++ b/packages/side-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seleniumhq/side-runtime",
-  "version": "4.0.0-alpha.16",
+  "version": "4.0.0-alpha.17",
   "description": "Selenium IDE playback and execution",
   "author": "Tomer <tomer@corevo.io>",
   "homepage": "http://github.com/SeleniumHQ/selenium-ide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ importers:
       '@seleniumhq/side-code-export': ^4.0.0-alpha.2
       '@seleniumhq/side-model': ^4.0.0-alpha.2
       '@seleniumhq/side-plugin-example': ^4.0.0-alpha.1
-      '@seleniumhq/side-runtime': ^4.0.0-alpha.16
+      '@seleniumhq/side-runtime': ^4.0.0-alpha.17
       '@types/copy-webpack-plugin': 8.0.1
       '@types/electron': 1.6.10
       '@types/electron-devtools-installer': ^2.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
   packages/side-runner:
     specifiers:
       '@seleniumhq/side-model': ^4.0.0-alpha.2
-      '@seleniumhq/side-runtime': ^4.0.0-alpha.15
+      '@seleniumhq/side-runtime': ^4.0.0-alpha.17
       '@types/glob': 7.2.0
       '@types/jest': ^27.4.1
       '@types/js-beautify': 1.13.3


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/1638850/209802663-36ca0666-04ff-4276-bf33-0106bf572d21.png)

the origin code of detect new win function `getAllWindowHandles` execute too quickly, so may cause cant find new win.

this commit is loop to getAllWindowHandles by timeout.

May be this https://github.com/SeleniumHQ/selenium-ide/issues/1568 is same 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
