### PR TITLE
new language opts for custom test/suite completions

### DIFF
--- a/packages/side-code-export/src/code-export/emit.ts
+++ b/packages/side-code-export/src/code-export/emit.ts
@@ -42,7 +42,10 @@ import { LanguageHooks } from './hook'
 export interface EmitterContext extends Omit<LanguageEmitterOpts, 'hooks'> {
   testLevel?: number
   commandLevel?: number
-  testDeclaration: string
+  suiteCompletion?: string
+  suiteDeclaration?: string
+  testCompletion?: string
+  testDeclaration?: string
   enableOriginTracing: boolean
   enableDescriptionAsComment: boolean
   hooks: LanguageHooks
@@ -351,6 +354,7 @@ async function emitTest(
   const {
     testLevel = 1,
     commandLevel = 2,
+    testCompletion,
     testDeclaration,
     terminatingKeyword,
     commandPrefixPadding,
@@ -411,7 +415,7 @@ async function emitTest(
   )
 
   // prepare result object
-  result.testDeclaration = render(testDeclaration, {
+  result.testDeclaration = render(testDeclaration!, {
     startingLevel: testLevel,
   }) as string
   result.inEachBegin = render(
@@ -439,7 +443,7 @@ async function emitTest(
       startingLevel: commandLevel,
     }
   ) as string
-  result.testEnd = render(terminatingKeyword, {
+  result.testEnd = render(testCompletion || terminatingKeyword, {
     startingLevel: testLevel,
   }) as string
 
@@ -453,12 +457,14 @@ async function emitTestsFromSuite(
   {
     enableOriginTracing,
     enableDescriptionAsComment,
+    generateTestCompletion,
     generateTestDeclaration,
     project,
   }: Pick<
     EmitterContext,
     | 'enableDescriptionAsComment'
     | 'enableOriginTracing'
+    | 'generateTestCompletion'
     | 'generateTestDeclaration'
     | 'project'
   >
@@ -467,9 +473,13 @@ async function emitTestsFromSuite(
   for (const testID of suite.tests) {
     const test = tests.find((test) => test.id === testID) as TestShape
     const testDeclaration = generateTestDeclaration(test.name)
+    const testCompletion = generateTestCompletion
+      ? generateTestCompletion(test.name)
+      : languageOpts.terminatingKeyword
     result[test.name] = await emitTest(test, tests, {
       ...languageOpts,
       testDeclaration,
+      testCompletion,
       enableOriginTracing,
       enableDescriptionAsComment,
       project,
@@ -480,6 +490,7 @@ async function emitTestsFromSuite(
 
 export interface EmittedSuite {
   suiteDeclaration: string
+  suiteCompletion?: string
   headerComment: string
   dependencies: string
   variables: string
@@ -501,6 +512,7 @@ async function emitSuite(
     commandPrefixPadding,
     hooks,
     suiteDeclaration,
+    suiteCompletion,
     suiteLevel,
     suiteName,
     suite,
@@ -513,6 +525,7 @@ async function emitSuite(
     | 'commandPrefixPadding'
     | 'hooks'
     | 'project'
+    | 'suiteCompletion'
     | 'terminatingKeyword'
   > & {
     beforeEachOptions?: any
@@ -596,7 +609,7 @@ async function emitSuite(
     }
   ) as string
   result.tests = body
-  result.suiteEnd = render(terminatingKeyword, {
+  result.suiteEnd = render(suiteCompletion || terminatingKeyword, {
     startingLevel: suiteLevel,
   }) as string
 

--- a/packages/side-code-export/src/types.ts
+++ b/packages/side-code-export/src/types.ts
@@ -99,7 +99,9 @@ export interface LanguageEmitterOpts {
   generateFilename: (name: string) => string
   generateMethodDeclaration: GenerateMethodDeclaration
   generateSuiteDeclaration: (name: string) => string
+  generateSuiteCompletion?: (name: string) => string
   generateTestDeclaration: (name: string) => string
+  generateTestCompletion?: (name: string) => string
   hooks: LanguageHooks
   name: string
   terminatingKeyword: string


### PR DESCRIPTION
@matewilk - How does something like this look for your purposes?

The idea here is that you can have generateTestCompletion or generateSuiteCompletion just like the declaration. Then, being able to be ahead of and behind it, you should be fine I think. 😄
