### PR TITLE
Add a Window Timeout Field in the Command Editor, for Commands Marked as Opening a Window

### DIFF
--- a/packages/selenium-ide/src/browser/I18N/en/index.ts
+++ b/packages/selenium-ide/src/browser/I18N/en/index.ts
@@ -177,6 +177,8 @@ const testCore = {
   value: 'Value',
   windowHandleName: 'Window Handle Name',
   windowHandleNameNote: 'Variable name to set to the new window handle',
+  windowTimeout: 'Window Timeout',
+  windowTimeoutNote: 'The amount of time to wait for the window to open (in milliseconds)',
   commands: 'Commands',
   tabCommand: 'Cmd',
   tabTarget: 'Target',

--- a/packages/selenium-ide/src/browser/I18N/zh/index.ts
+++ b/packages/selenium-ide/src/browser/I18N/zh/index.ts
@@ -183,6 +183,8 @@ const testCore = {
   value: '指令值',
   windowHandleName: '窗口句柄名称',
   windowHandleNameNote: '要设置为新窗口句柄的变量名称',
+  windowTimeout: '窗口超时',
+  windowTimeoutNote: '等待窗口打开的时间量（以毫秒为单位）',
   commands: '指令集',
   tabCommand: '指令',
   tabTarget: '关键字',

--- a/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/TestCommandEditor.tsx
+++ b/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/TestCommandEditor.tsx
@@ -70,18 +70,32 @@ const CommandEditor: FC<CommandEditorProps> = ({
         <ArgField command={correctedCommand} {...props} fieldName="target" />
         <ArgField command={correctedCommand} {...props} fieldName="value" />
         {command.opensWindow && (
-          <CommandTextField
-            command={correctedCommand}
-            {...props}
-            fieldName={
-              intl.formatMessage({
-                id: languageMap.testCore.windowHandleName,
-              }) as 'windowHandleName'
-            }
-            note={intl.formatMessage({
-              id: languageMap.testCore.windowHandleNameNote,
-            })}
-          />
+          <>
+            <CommandTextField
+              command={correctedCommand}
+              {...props}
+              fieldName={
+                intl.formatMessage({
+                  id: languageMap.testCore.windowHandleName,
+                }) as 'windowHandleName'
+              }
+              note={intl.formatMessage({
+                id: languageMap.testCore.windowHandleNameNote,
+              })}
+            />
+            <CommandTextField
+              command={correctedCommand}
+              {...props}
+              fieldName={
+                intl.formatMessage({
+                  id: languageMap.testCore.windowTimeout,
+                }) as 'windowTimeout'
+              }
+              note={intl.formatMessage({
+                id: languageMap.testCore.windowTimeoutNote,
+              })}
+              />
+            </>
         )}
         <CommandTextField
           command={correctedCommand}

--- a/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/types.ts
+++ b/packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/types.ts
@@ -17,7 +17,7 @@ export interface CommandArgFieldProps extends CommandEditorProps {
 }
 
 export interface CommandFieldProps extends CommandEditorProps {
-  fieldName: 'comment' | 'windowHandleName' | LocatorFields
+  fieldName: 'comment' | 'windowHandleName' | 'windowTimeout' | LocatorFields
   note?: string
 }
 


### PR DESCRIPTION
### **User description**
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds a text field to the command editor that allows you to specify the window timeout if a command is flagged as opening a window.

### Motivation and Context
(Copied from Issue #1829)
I use Selenium IDE to test a website which occasionally has quite long page load times. As a consequence of this, the default 2 second timeout on opening a window is too short, and frequently causes tests to fail when they're actually fine. It's possible to change this behaviour by editing the .side file itself, but it's not exactly the cleanest way of doing it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new text field in the command editor for specifying a timeout when commands are flagged to open a new window.
- Updated English and Chinese localizations to include descriptions for the new window timeout field.
- Modified the command editor to conditionally display the new window timeout field based on command properties.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add English Localization for Window Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/selenium-ide/src/browser/I18N/en/index.ts

<li>Added new entries for 'windowTimeout' and 'windowTimeoutNote' to <br>support the new window timeout functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium-ide/pull/1830/files#diff-09220e8cb63d46b1464908342c3fb14ca4815e8eaae78409130bdf4080eb93b9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add Chinese Localization for Window Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/selenium-ide/src/browser/I18N/zh/index.ts

<li>Added new entries for 'windowTimeout' and 'windowTimeoutNote' in <br>Chinese to support the new window timeout functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium-ide/pull/1830/files#diff-252ec41818e7e19f57caddce35b06b2d0757ff585a656bbb4b2148cbdd697a52">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TestCommandEditor.tsx</strong><dd><code>Implement Window Timeout Field in Command Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/TestCommandEditor.tsx

<li>Added a new text field for specifying window timeout when a command <br>opens a new window.<br> <li> This field only appears if the command is flagged to open a window.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium-ide/pull/1830/files#diff-07c688d33f7d459853b0094e4779718c25ea976d15f251f413d6afbbf0430e70">+26/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Update Command Field Types to Include Window Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/selenium-ide/src/browser/windows/ProjectEditor/tabs/Tests/types.ts

<li>Updated the 'CommandFieldProps' interface to include 'windowTimeout' <br>as a possible field name.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium-ide/pull/1830/files#diff-354b107b95ad562e66b7939c08756a00b6eab8967ce6b9ed793f9721d36f0698">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

